### PR TITLE
[SPRINT #1 3차 수정사항 - 사이드바 a 태그 중복 브라우저 에러 처리]

### DIFF
--- a/client/web/src/organisms/mypage/layouts/navbar/HeaderLinks.tsx
+++ b/client/web/src/organisms/mypage/layouts/navbar/HeaderLinks.tsx
@@ -36,7 +36,7 @@ function HeaderLinks(props: HeaderLinksProps): JSX.Element {
   const notificationRef = useRef<HTMLButtonElement | null>(null);
   const classes = useNavbarStyles();
   const {
-    anchorEl, handleAnchorOpen, handleAnchorOpenWithRef, handleAnchorClose
+    anchorEl, handleAnchorOpen, handleAnchorClose
   } = useAnchorEl();
 
   // 개인 알림 - GET Request
@@ -48,13 +48,8 @@ function HeaderLinks(props: HeaderLinksProps): JSX.Element {
     }
   });
 
-  React.useEffect(() => {
-    console.log(getError);
-  });
-
   // 자식 컴포넌트에서 안읽은 알림을 클릭했는지를 검사하기 위한 state
   const [changeReadState, setChangeReadState] = React.useState<boolean>(false);
-  const [open, setOpen] = React.useState(false);
   React.useEffect(() => {
     if (changeReadState) {
       excuteGet();

--- a/client/web/src/organisms/mypage/layouts/testsidebar/TestSidebar.tsx
+++ b/client/web/src/organisms/mypage/layouts/testsidebar/TestSidebar.tsx
@@ -11,6 +11,7 @@ import {
 // @material-ui/icons icon
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import MaximizeIcon from '@material-ui/icons/Maximize';
+
 import { MypageRoute } from '../../../../pages/mypage/routes';
 // styles
 import useTestStyle from './TestSidebar.style';
@@ -31,13 +32,7 @@ export default function TestSidebar({
   return (
     <List className={classes.conatiner}>
       {routes.map((route) => (
-        <Link // 서브라우터 존재시 해당 상위 탭 클릭시 하위 탭 첫 번째 페이지를 default 로 설정
-          to={route.subRoutes
-            ? (route.subRoutes[0].layout + route.subRoutes[0].path)
-            : (route.layout + route.path)}
-          key={route.layout + route.path}
-          style={{ textDecoration: 'none' }}
-        >
+        <div key={route.name}>
           <ListItem
             key={route.name}
             className={classes.listItem}
@@ -46,48 +41,57 @@ export default function TestSidebar({
           >
             <Grid container item direction="column">
               <Accordion square className={classes.accordian}>
-                <AccordionSummary className={classes.accordianHeader}>
-                  <Grid container direction="row" justify="flex-start">
-                    <Grid item xs={1}>
-                      {isActiveRoute(route.path) && (
+                <Link // 서브라우터 존재시 해당 상위 탭 클릭시 하위 탭 첫 번째 페이지를 default 로 설정
+                  to={route.subRoutes
+                    ? (route.subRoutes[0].layout + route.subRoutes[0].path)
+                    : (route.layout + route.path)}
+                  key={route.layout + route.path}
+                  style={{ textDecoration: 'none', color: 'black' }}
+                >
+                  <AccordionSummary className={classes.accordianHeader}>
+
+                    <Grid container direction="row" justify="flex-start">
+                      <Grid item xs={1}>
+                        {isActiveRoute(route.path) && (
                         <MaximizeIcon className={classes.selectedIndicator} />
-                      )}
-                    </Grid>
-                    <Grid item xs={3}>
-                      {route.icon && (
-                      <ListItemIcon>
-                        <route.icon className={classnames({
-                          [classes.icon]: true,
-                          [classes.selected]: isActiveRoute(route.path)
-                        })}
-                        />
-                      </ListItemIcon>
-                      )}
-                    </Grid>
-                    <Grid item xs={8}>
-                      <ListItemText>
-                        <Typography
-                          variant="h6"
-                          className={classnames({
-                            [classes.selected]: isActiveRoute(route.path),
-                            [classes.notSelectedTab]: !isActiveRoute(route.path),
+                        )}
+                      </Grid>
+                      <Grid item xs={3}>
+                        {route.icon && (
+                        <ListItemIcon>
+                          <route.icon className={classnames({
+                            [classes.icon]: true,
+                            [classes.selected]: isActiveRoute(route.path)
                           })}
-                        >
-                          {route.name}
-                        </Typography>
-                      </ListItemText>
+                          />
+                        </ListItemIcon>
+                        )}
+                      </Grid>
+                      <Grid item xs={8}>
+                        <ListItemText>
+                          <Typography
+                            variant="h6"
+                            className={classnames({
+                              [classes.selected]: isActiveRoute(route.path),
+                              [classes.notSelectedTab]: !isActiveRoute(route.path),
+                            })}
+                          >
+                            {route.name}
+                          </Typography>
+                        </ListItemText>
+                      </Grid>
                     </Grid>
-                  </Grid>
 
-                </AccordionSummary>
-
+                  </AccordionSummary>
+                </Link>
                 {/* 서브라우터가 존재 하는 경우 */}
                 {route.subRoutes && (
                 <AccordionDetails className={classes.subRouteList}>
                   {route.subRoutes.map((subroute) => (
-                    <div
+                    <Link
                       key={subroute.layout + subroute.path}
                       className={classes.subRouteLink}
+                      to={subroute.layout + subroute.path}
                     >
                       <ArrowForwardIosIcon color="primary" fontSize="small" />
                       <Typography
@@ -96,20 +100,23 @@ export default function TestSidebar({
                           [classes.selected]: isActiveRoute(subroute.path),
                           [classes.notSelectedTab]: !isActiveRoute(subroute.path),
                         })}
-                        to={subroute.layout + subroute.path}
-                        component={Link}
                       >
                         {subroute.name}
                       </Typography>
-                    </div>
+                    </Link>
+
                   ))}
                 </AccordionDetails>
+
                 )}
               </Accordion>
+
             </Grid>
+
           </ListItem>
           <Divider />
-        </Link>
+        </div>
+        // </Link>
       ))}
     </List>
   );


### PR DESCRIPTION
1. 네비바 - 헤더 링크 필요없는 코드 삭제 -> Warnning 제거
2. 사이드바 - Link 컴포넌트 서브라우터 유무에 따라 분리 -> Warnning , Error 제거