### PR TITLE
[TP-SPRINT #2.1] 디자인 수정 - 마이페이지:방송분석:방송별비교

### DIFF
--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/Calendar.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/Calendar.tsx
@@ -21,8 +21,7 @@ import classnames from 'classnames';
 import CenterLoading from '../../../../atoms/Loading/CenterLoading';
 // interface
 import { StreamCalendarProps } from './StreamCompareSectioninterface';
-// context
-import SubscribeContext from '../../../../utils/contexts/SubscribeContext';
+import useAuthContext from '../../../../utils/hooks/useAuthContext';
 
 const useStyles = makeStyles((theme: Theme) => ({
   hasStreamDayDot: {
@@ -47,7 +46,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
     compareStream, baseStream, handleError,
   } = props;
   const classes = useStyles();
-  const subscribe = React.useContext(SubscribeContext);
+  const auth = useAuthContext();
   const [hasStreamDays, setHasStreamDays] = React.useState<number[]>([]);
   const [currMonth, setCurrMonth] = React.useState<MaterialUiPickersDate>();
 
@@ -62,7 +61,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
 
   React.useEffect(() => {
     const params: SearchCalendarStreams = {
-      userId: subscribe.currUser.targetUserId,
+      userId: auth.user.userId,
       startDate: currMonth ? currMonth.toISOString() : (new Date()).toISOString(),
     };
 
@@ -80,7 +79,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
         });
       }
     });
-  }, [subscribe.currUser, currMonth, excuteGetStreams, handleError]);
+  }, [auth.user.userId, currMonth, excuteGetStreams, handleError]);
 
   const handleDayChange = (newDate: MaterialUiPickersDate) => {
     if (newDate) setClickedDate(newDate);
@@ -101,7 +100,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
     if (newMonth) {
       setCurrMonth(newMonth);
       const params: SearchCalendarStreams = {
-        userId: subscribe.currUser.targetUserId,
+        userId: auth.user.userId,
         startDate: newMonth.toISOString(),
       };
 

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCard.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCard.tsx
@@ -22,6 +22,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   base: { marginRight: theme.spacing(2) },
   compare: { marginLeft: theme.spacing(2) },
+  baseIcon: { color: theme.palette.primary.dark },
+  compareIcon: { color: theme.palette.secondary.main },
+  baseBeforeIcon: { color: theme.palette.primary.light },
+  compareBeforeIcon: { color: theme.palette.secondary.light },
   dotted: {
     borderColor: theme.palette.action.selected,
     borderStyle: 'dashed',
@@ -69,7 +73,7 @@ export default function StreamCard(props: StreamCardProps): JSX.Element {
         >
           <div className={classes.titleContainer}>
             <div className={classes.title}>
-              <VideocamIcon color={base ? 'primary' : 'secondary'} fontSize="large" />
+              <VideocamIcon className={base ? classes.baseBeforeIcon : classes.compareBeforeIcon} fontSize="large" />
               <Typography variant="h6" color="textSecondary" className={classes.titleText}>
                 {base ? '기준 방송' : '비교 방송'}
               </Typography>
@@ -91,7 +95,7 @@ export default function StreamCard(props: StreamCardProps): JSX.Element {
           {/* 타이틀 */}
           <div className={classes.titleContainer}>
             <div className={classes.title}>
-              <VideocamIcon color={base ? 'primary' : 'secondary'} fontSize="large" />
+              <VideocamIcon className={base ? classes.baseIcon : classes.compareIcon} fontSize="large" />
               <Typography variant="h6" className={classes.titleText}>
                 {base ? '기준 방송' : '비교 방송'}
               </Typography>

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCard.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCard.tsx
@@ -1,72 +1,36 @@
 import React from 'react';
-// material-ui core components
 import moment from 'moment';
 import classnames from 'classnames';
+// material-ui core components
 import {
-  Card, CardContent, Typography, Grid, IconButton,
+  Typography, IconButton, Paper,
 } from '@material-ui/core';
 // styles
 import { makeStyles, Theme } from '@material-ui/core/styles';
+// icons
+import VideocamIcon from '@material-ui/icons/Videocam';
 import ClearOutlinedIcon from '@material-ui/icons/ClearOutlined';
 // interface
 import { StreamCardProps } from './StreamCompareSectioninterface';
 
 const useStyles = makeStyles((theme: Theme) => ({
   cardWrapper: {
-    borderTopRightRadius: '0px',
-    borderTopLeftRadius: '0px',
-    borderBottomRightRadius: '12px',
-    borderBottomLeftRadius: '12px',
-    width: '100%',
-    minHeight: '134px',
-    boxShadow: 'none',
+    padding: theme.spacing(2),
+    width: 400,
+    height: 200,
+    overflow: 'hidden',
   },
-  cardTitleWrapper: {
-    width: '100%',
-    backgroundColor: '#b5b5b5',
-    height: '46px',
+  base: { marginRight: theme.spacing(2) },
+  compare: { marginLeft: theme.spacing(2) },
+  dotted: {
+    borderColor: theme.palette.action.selected,
+    borderStyle: 'dashed',
+    borderRadius: 5,
   },
-  cardTitleCompWrapper: {
-    width: '100%',
-    backgroundColor: '#8699c1',
-    height: '46px',
-  },
-  cardBodyWrapper: {
-    width: '100%',
-    backgroundColor: theme.palette.background.paper,
-    minHeight: '130px',
-    paddingTop: '11px',
-    paddingBottom: '11px',
-  },
-  cardBodyCompWrapper: {
-    width: '100%',
-    backgroundColor: '#a6c1f9',
-    minHeight: '130px',
-    paddingTop: '11px',
-    paddingBottom: '11px',
-  },
-  cardTitle: {
-    fontSize: '22px',
-    marginLeft: '13px',
-    fontWeight: 'bold',
-    fontFamily: 'AppleSDGothicNeo',
-    color: theme.palette.text.primary,
-    lineHeight: '1.5',
-    overflow: 'auto',
-    display: 'flex',
-    marginTop: '4px',
-    alignItems: 'center',
-  },
-  cardBody: {
-    fontSize: '22px',
-    marginLeft: '20px',
-    fontFamily: 'AppleSDGothicNeo',
-    color: theme.palette.text.secondary,
-    lineHeight: '1.5',
-    overflow: 'auto',
-    width: '100%',
-    marginBottom: '10px',
-  },
+  titleContainer: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
+  title: { display: 'flex', alignItems: 'center' },
+  titleText: { marginLeft: theme.spacing(2), fontWeight: 'bold' },
+  contents: { padding: theme.spacing(2), marginLeft: theme.spacing(4) },
 }));
 
 export default function StreamCard(props: StreamCardProps): JSX.Element {
@@ -75,70 +39,88 @@ export default function StreamCard(props: StreamCardProps): JSX.Element {
   } = props;
   const classes = useStyles();
 
+  // 방송시간 날짜 Formmater
   const airTimeFormmater = (startDate: Date, streamLength: number) => {
     const endAt = new Date(startDate);
     endAt.setHours(startDate.getHours() + streamLength);
     const airTimeText = `${startDate.getDate()}일
-                        ${moment(startDate).format('HH:mm')}~ 
+                        ${moment(startDate).format('HH:mm')} ~ 
                         ${endAt.getDate()}일
                         ${moment(endAt).format('HH:mm')}`;
     return airTimeText;
   };
 
   const handleCloseButton = () => {
-    if (base) {
-      handleSeletedStreams(null, true);
-    } else {
-      handleSeletedStreams(null);
-    }
+    if (base)handleSeletedStreams(null, true);
+    else handleSeletedStreams(null);
   };
 
+  // 제목 글자수 제한
+  const TITLE_STR_LIMIT = 40;
+
   return (
-    <Card className={classes.cardWrapper}>
-      <CardContent style={{ padding: '0px' }}>
-        <Grid
-          container
+    <>
+      {!stream ? ( // 방송이 아직 선택되지 않은 경우
+        <Paper
+          elevation={0}
           className={classnames({
-            [classes.cardTitleWrapper]: base,
-            [classes.cardTitleCompWrapper]: !base,
+            [classes.cardWrapper]: true, [classes.dotted]: true, [classes.base]: base, [classes.compare]: !base,
           })}
-          direction="row"
-          justify="space-between"
         >
-
-          <Grid item>
-            <Typography variant="body1" className={classes.cardTitle}>
-              {platformIcon(stream)}
-              {base ? '기준 방송' : '비교 방송'}
+          <div className={classes.titleContainer}>
+            <div className={classes.title}>
+              <VideocamIcon color={base ? 'primary' : 'secondary'} fontSize="large" />
+              <Typography variant="h6" color="textSecondary" className={classes.titleText}>
+                {base ? '기준 방송' : '비교 방송'}
+              </Typography>
+            </div>
+          </div>
+          <div className={classes.contents}>
+            <Typography variant="h6" color="textSecondary" style={{ textDecoration: 'underline' }}>
+              아래 목록에서 방송을 선택해주세요.
             </Typography>
-          </Grid>
-
-          <IconButton
-            onClick={handleCloseButton}
-          >
-            <ClearOutlinedIcon />
-          </IconButton>
-
-        </Grid>
-        <Grid
-          container
-          alignContent="center"
+          </div>
+        </Paper>
+      ) : (
+        // 방송이 선택된 경우
+        <Paper
           className={classnames({
-            [classes.cardBodyWrapper]: base,
-            [classes.cardBodyCompWrapper]: !base,
+            [classes.cardWrapper]: true, [classes.base]: base, [classes.compare]: !base,
           })}
         >
+          {/* 타이틀 */}
+          <div className={classes.titleContainer}>
+            <div className={classes.title}>
+              <VideocamIcon color={base ? 'primary' : 'secondary'} fontSize="large" />
+              <Typography variant="h6" className={classes.titleText}>
+                {base ? '기준 방송' : '비교 방송'}
+              </Typography>
+            </div>
+            <IconButton onClick={handleCloseButton}>
+              <ClearOutlinedIcon />
+            </IconButton>
+          </div>
 
-          <Typography className={classes.cardBody} display="block">
-            {stream.title}
-          </Typography>
-
-          <Typography className={classes.cardBody}>
-            {airTimeFormmater(new Date(stream.startedAt), stream.airTime)}
-          </Typography>
-
-        </Grid>
-      </CardContent>
-    </Card>
+          {/* 카드 몸체 */}
+          <div className={classes.contents}>
+            {stream.title.length > TITLE_STR_LIMIT
+              ? (
+                <Typography variant="h6" color="textSecondary">
+                  {`${stream.title.slice(0, TITLE_STR_LIMIT - 3)}...`}
+                </Typography>
+              ) : (
+                <Typography variant="h6" color="textSecondary">
+                  {stream.title}
+                </Typography>
+              )}
+            <Typography variant="body1" color="textSecondary">
+              {airTimeFormmater(new Date(stream.startedAt), stream.airTime)}
+              {' '}
+              {platformIcon(stream)}
+            </Typography>
+          </div>
+        </Paper>
+      )}
+    </>
   );
 }

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.style.ts
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.style.ts
@@ -2,9 +2,7 @@ import { Theme, makeStyles } from '@material-ui/core/styles';
 
 const useStreamSectionStyles = makeStyles((theme: Theme) => ({
   root: {
-    flexGrow: 1,
     marginTop: theme.spacing(4),
-    height: '700px',
   },
   titleDivider: {
     backgroundColor: theme.palette.primary.main,

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
@@ -147,7 +147,7 @@ export default function StreamCompareSection(
         <Loading clickOpen={loading} lodingTime={10000} />
       )}
 
-      <Grid container direction="column">
+      <Grid container direction="column" spacing={2}>
         <Grid item>
           <SectionTitle mainTitle="방송별 비교" />
           <Typography className={classes.mainBody}>

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 // material-ui core components
 import {
-  Typography, Grid, Divider, Button, Collapse,
+  Typography, Grid, Button, Collapse,
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 // shared dtos , interfaces

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
@@ -1,12 +1,7 @@
 import React, { useEffect } from 'react';
 // material-ui core components
 import {
-  Paper,
-  Typography,
-  Grid,
-  Divider,
-  Button,
-  Collapse,
+  Typography, Grid, Divider, Button, Collapse,
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 // shared dtos , interfaces
@@ -151,37 +146,52 @@ export default function StreamCompareSection(
         <Loading clickOpen={loading} lodingTime={10000} />
       )}
       <Divider className={classes.titleDivider} />
-      <Grid container direction="column">
+      <Grid container direction="column" spacing={2}>
+        {/* 제목 및 설명 */}
         <Grid item>
-          <Typography className={classes.mainTitle}>방송별 리스트</Typography>
+          <Typography className={classes.mainTitle}>방송별 비교</Typography>
           <Typography className={classes.mainBody}>
             두 방송을 선택하시면 방송 비교 분석을 시작합니다.
           </Typography>
         </Grid>
-        <Grid
-          item
-          container
-          style={{ marginBottom: '5px' }}
-          direction="row"
-          alignItems="flex-end"
-        >
-          <Paper elevation={0} className={classes.bodyPapper}>
-            <Typography className={classes.subTitle}>
-              <SelectDateIcon
-                style={{ fontSize: '32.5px', marginRight: '26px' }}
-              />
-              날짜 선택
-            </Typography>
-          </Paper>
-          <Collapse
-            in={fullMessageOpen}
-            style={{ height: 'auto', marginLeft: '20px' }}
-          >
+
+        {/* 선택된 방송 목록 */}
+        <Grid item xs container alignItems="center">
+          {/* 리스트 클릭시 base , compare 방송 정보 카드 렌더링 */}
+          <Grid item>
+            <StreamCard
+              stream={baseStream}
+              handleSeletedStreams={handleSeletedStreams}
+              platformIcon={platformIcon}
+              base
+            />
+          </Grid>
+
+          <Grid item>
+            <Typography variant="h6">VS</Typography>
+          </Grid>
+
+          <Grid item>
+            <StreamCard
+              stream={compareStream}
+              handleSeletedStreams={handleSeletedStreams}
+              platformIcon={platformIcon}
+            />
+          </Grid>
+        </Grid>
+
+        {/* 오류 alert  */}
+        {fullMessageOpen && (
+        <Grid item xs={6}>
+          <Collapse in={fullMessageOpen}>
             <Alert severity="error" className={classes.alert}>
               x 표시를 눌러 삭제후 추가해주세요
             </Alert>
           </Collapse>
         </Grid>
+        )}
+
+        {/* 달력 선택 */}
         <Grid item container direction="row" xs={12}>
           <Grid className={classes.bodyWrapper} container xs={8} item>
             <Grid item xs style={{ width: '310px' }}>
@@ -218,30 +228,6 @@ export default function StreamCompareSection(
                 handleFullMessage={handleFullMessage}
                 platformIcon={platformIcon}
               />
-            </Grid>
-          </Grid>
-
-          <Grid item xs container direction="column">
-            {/* 리스트 클릭시 base , compare 방송 정보 카드 렌더링 */}
-            <Grid item style={{ marginBottom: '27px' }}>
-              {baseStream && (
-                <StreamCard
-                  stream={baseStream}
-                  handleSeletedStreams={handleSeletedStreams}
-                  platformIcon={platformIcon}
-                  base
-                />
-              )}
-            </Grid>
-
-            <Grid item style={{ marginBottom: '0px' }}>
-              {compareStream && (
-                <StreamCard
-                  stream={compareStream}
-                  handleSeletedStreams={handleSeletedStreams}
-                  platformIcon={platformIcon}
-                />
-              )}
             </Grid>
           </Grid>
         </Grid>

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSectioninterface.ts
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSectioninterface.ts
@@ -21,7 +21,7 @@ export interface StreamListProps {
 }
 
 export interface StreamCardProps {
-  stream: DayStreamsInfo;
+  stream: DayStreamsInfo | null;
   base? : true|null;
   platformIcon: (stream: DayStreamsInfo) => JSX.Element;
   handleSeletedStreams: (newStreams: DayStreamsInfo|null, base?: true | undefined) => void

--- a/client/web/src/pages/mypage/stream-analysis/StreamAnalysis.tsx
+++ b/client/web/src/pages/mypage/stream-analysis/StreamAnalysis.tsx
@@ -17,15 +17,14 @@ import StreamMetrics from '../../../organisms/mypage/stream-analysis/StreamMetri
 export default function StreamAnalysis(): JSX.Element {
   const [data, setData] = useState<StreamAnalysisResType[]>([]);
   const [open, setOpen] = useState<boolean>(false);
+
   const [{ loading, error }, getRequest] = useAxios<StreamAnalysisResType[]>(
     '/stream-analysis/streams', { manual: true },
   );
   const subscribe = React.useContext(SubscribeContext);
   const handleSubmit = (params: SearchStreamInfoByStreamId) => {
     setOpen(false);
-    getRequest({
-      params,
-    })
+    getRequest({ params })
       .then((res) => {
         setData(res.data);
         setOpen(true);

--- a/client/web/src/theme.tsx
+++ b/client/web/src/theme.tsx
@@ -18,21 +18,28 @@ const rawTheme: ThemeOptions = {
       contrastText: '#fff',
     },
     secondary: {
-      light: lighten('#79e2e0', 0.1),
+      light: lighten('#79e2e0', 0.5),
       main: '#79e2e0',
-      dark: darken('#79e2e0', 0.1),
+      dark: darken('#79e2e0', 0.2),
       contrastText: '#fff',
     },
+    // 파랑 계열 색상
     info: {
       light: '#9AA2C5',
       main: blueGrey[400],
       dark: blueGrey[600],
     },
+    // 초록 계열 색상
     success: {
       light: '#f0a9b3',
       main: '#ff3e7a',
       contrastText: '#fff',
     },
+    // // 레드 계열 색상
+    // error : { },
+    // // 주황 계열 색상
+    // warn : { },
+    // }
   },
   typography: {
     fontFamily: '-apple-system, BlinkMacSystemFont, "AppleSDGothicNeo", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',


### PR DESCRIPTION
### 방송별 비교

- "날짜 선택" 버튼 삭제
    - [x]  삭제

- 기준방송과 비교방송 보여주는 방식 수정
( 회색 자리차지 → 선택하면 기준방송 또는 비교방송 자리에 카드 생성 )
    - [x]  기준방송, 비교방송 선택 된 컴포넌트 생성
    - [x]  기준방송, 비교방송 미선택 컴포넌트 생성
    - [x] 제목 글자 제한하여 ...처리
- 방송분석 -> 분석하기 진행시 분석된 정보와 분석준비섹션이 겹치게 보이는 버그 수정
    - [x] height 고정 제거

- theme secondary 에메랄드 색상 변경
    - [x] light, dark 농도만 변경

![image](https://user-images.githubusercontent.com/43170520/97837258-2cf03c80-1d21-11eb-93b3-29e70fe43445.png)
