### PR TITLE
각 사이트바 탭의 섹션 타이틀 컴포넌트 재사용을 통한 통일화

### DIFF
--- a/client/web/src/organisms/mypage/layouts/HighlightAnalysisLayout.style.ts
+++ b/client/web/src/organisms/mypage/layouts/HighlightAnalysisLayout.style.ts
@@ -2,10 +2,6 @@ import { makeStyles } from '@material-ui/core';
 
 const useHighlightAnalysisLayoutStyles = makeStyles((theme) => ({
   root: { padding: theme.spacing(4) },
-  title: {
-    fontWeight: 'bold',
-    fontSize: '30px',
-  },
   sub: {
     fontSize: 22,
     color: theme.palette.text.secondary,

--- a/client/web/src/organisms/mypage/layouts/HighlightAnalysisLayout.tsx
+++ b/client/web/src/organisms/mypage/layouts/HighlightAnalysisLayout.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
-import Divider from '@material-ui/core/Divider';
 import useAxios from 'axios-hooks';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -14,6 +13,7 @@ import useHighlightAnalysisLayoutStyles from './HighlightAnalysisLayout.style';
 import TruepointHighlight from '../highlightAnalysis/TruepointHighlight';
 import MetricsAccordian from '../highlightAnalysis/MetricsAccordian';
 import Loading from '../../shared/sub/Loading';
+import SectionTitle from '../../shared/sub/SectionTitles';
 
 interface StreamDate {
   fullDate: Date;
@@ -238,16 +238,10 @@ export default function HighlightAnalysisLayout(): JSX.Element {
         direction="column"
       >
         <Grid item xs={12} className={classes.root}>
-          <Grid item xs={3}>
-            <Divider variant="middle" component="hr" />
-          </Grid>
-          <Typography variant="h4" className={classes.title}>
-            편집점 분석
-          </Typography>
+          <SectionTitle mainTitle="편집점 분석" />
           <Typography variant="body1" className={classes.sub}>
             방송을 선택하시면 편집점 분석을 시작합니다.
           </Typography>
-          <Divider variant="middle" />
         </Grid>
         <Grid
           item
@@ -257,7 +251,7 @@ export default function HighlightAnalysisLayout(): JSX.Element {
           alignItems="center"
         >
           <Grid item xs={12} className={classes.root}>
-            <Typography variant="h4" className={classes.checkedStreamFont}>
+            <Typography variant="h4" className={classes.sub}>
               선택된 방송 &gt;
             </Typography>
           </Grid>

--- a/client/web/src/organisms/mypage/stream-analysis/StreamMetrics.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/StreamMetrics.tsx
@@ -8,6 +8,7 @@ import classnames from 'classnames';
 import StackedGraph from '../graph/StackedGraph';
 import { metricInterface } from '../graph/graphsInterface';
 import MetricIcons from '../../../atoms/Graph-icons/MetricIcons';
+import SectionTitle from '../../shared/sub/SectionTitles';
 
 const useStyles = makeStyles((theme) => ({
   center: {
@@ -62,9 +63,10 @@ export default function StreamAnalysis(
           <CircularProgress />
         </Grid>
       )}  => 로딩도 멈추는 현상 */}
+      <SectionTitle mainTitle="채팅 발생수 평균 비교" />
       {open
        && (metricData.map((element, index) => (
-         <Grid item xs={12} container direction="row" key={shortid.generate()}>
+         <Grid item xs={12} container direction="row" key={shortid.generate()} style={{ marginTop: '32px' }}>
            <Grid item xs={2} className={classes.center}>
              {iconArray[index]}
              <Typography className={classes.head}>{element.title}</Typography>

--- a/client/web/src/organisms/mypage/stream-analysis/period-analysis/PeriodAnalysisSection.style.ts
+++ b/client/web/src/organisms/mypage/stream-analysis/period-analysis/PeriodAnalysisSection.style.ts
@@ -5,12 +5,6 @@ const usePeriodAnalysisSectionStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
     marginTop: theme.spacing(4),
   },
-  titleDivider: {
-    backgroundColor: theme.palette.primary.main,
-    width: '200px',
-    marginBottom: '12px',
-    height: '3px',
-  },
   mainTitle: {
     color: theme.palette.text.primary,
     letterSpacing: '-1.2px',

--- a/client/web/src/organisms/mypage/stream-analysis/period-analysis/PeriodAnalysisSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/period-analysis/PeriodAnalysisSection.tsx
@@ -4,7 +4,6 @@ import {
   Paper,
   Typography,
   Grid,
-  Divider,
   Button,
   Collapse,
 } from '@material-ui/core';
@@ -36,6 +35,7 @@ import Loading from '../../../shared/sub/Loading';
 import ErrorSnackBar from '../../../../atoms/snackbar/ErrorSnackBar';
 // context
 import SubscribeContext from '../../../../utils/contexts/SubscribeContext';
+import SectionTitle from '../../../shared/sub/SectionTitles';
 
 export default function PeriodAnalysisSection(
   props: PeriodAnalysisProps,
@@ -181,10 +181,9 @@ export default function PeriodAnalysisSection(
           <Loading clickOpen={loading} lodingTime={10000} />
         )}
 
-        <Divider className={classes.titleDivider} />
         <Grid container direction="column">
           <Grid item>
-            <Typography className={classes.mainTitle}>기간 추세분석</Typography>
+            <SectionTitle mainTitle="기간 추세 분석" />
             <Typography className={classes.mainBody}>
               추세 분석을 위한 기간 설정
             </Typography>

--- a/client/web/src/organisms/mypage/stream-analysis/period-vs-period/PeriodCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/period-vs-period/PeriodCompareSection.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 // material-ui core components
 import {
-  Typography, Grid, Divider, Button,
+  Typography, Grid, Button,
 } from '@material-ui/core';
 // axios
 import useAxios from 'axios-hooks';
@@ -21,6 +21,8 @@ import ErrorSnackBar from '../../../../atoms/snackbar/ErrorSnackBar';
 import SubscribeContext from '../../../../utils/contexts/SubscribeContext';
 // interfaces
 import { PeriodCompareProps, FatalError } from './PeriodCompareSection.interface';
+// componentShared
+import SectionTitle from '../../../shared/sub/SectionTitles';
 
 export default function PeriodCompareSection(props: PeriodCompareProps): JSX.Element {
   const {
@@ -149,10 +151,7 @@ export default function PeriodCompareSection(props: PeriodCompareProps): JSX.Ele
           />
           )}
 
-      <Divider className={classes.titleDivider} />
-      <Typography className={classes.mainTitle}>
-        기간 대 기간 분석
-      </Typography>
+      <SectionTitle mainTitle="기간대 기간 분석" />
       <Typography className={classes.infoText}>
         * 데이터 제공 기간을 벗어난 데이터는 확인하실 수 없습니다.
       </Typography>

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.style.ts
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.style.ts
@@ -6,12 +6,6 @@ const useStreamSectionStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(4),
     height: '700px',
   },
-  titleDivider: {
-    backgroundColor: theme.palette.primary.main,
-    width: '200px',
-    marginBottom: '12px',
-    height: '3px',
-  },
   mainTitle: {
     color: theme.palette.text.primary,
     letterSpacing: '-1.2px',

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
@@ -4,7 +4,6 @@ import {
   Paper,
   Typography,
   Grid,
-  Divider,
   Button,
   Collapse,
 } from '@material-ui/core';
@@ -23,6 +22,7 @@ import AfreecaIcon from '../../../../atoms/stream-analysis-icons/AfreecaIcon';
 import StreamCalendar from './Calendar';
 import StreamCard from './StreamCard';
 import StreamList from './StreamList';
+import SectionTitle from '../../../shared/sub/SectionTitles';
 // style
 import useStreamHeroStyles from './StreamCompareSection.style';
 // interface
@@ -150,10 +150,10 @@ export default function StreamCompareSection(
       {!(error?.isError || innerError.isError) && (
         <Loading clickOpen={loading} lodingTime={10000} />
       )}
-      <Divider className={classes.titleDivider} />
+
       <Grid container direction="column">
         <Grid item>
-          <Typography className={classes.mainTitle}>방송별 리스트</Typography>
+          <SectionTitle mainTitle="방송별 비교" />
           <Typography className={classes.mainBody}>
             두 방송을 선택하시면 방송 비교 분석을 시작합니다.
           </Typography>

--- a/client/web/src/organisms/shared/sub/MetricTitle.tsx
+++ b/client/web/src/organisms/shared/sub/MetricTitle.tsx
@@ -1,18 +1,9 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Divider, Typography, Grid } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import SectionTitle from './SectionTitles';
 
 const styles = makeStyles((theme) => ({
-  hr: {
-    margin: `${theme.spacing(1)}px 0px`,
-    backgroundColor: theme.palette.primary.main,
-    height: theme.spacing(0.5),
-  },
-  title: {
-    fontWeight: 'bold',
-    fontSize: 30,
-    margin: `${theme.spacing(1)}px 0px`,
-  },
   content: {
     fontSize: 22,
     fontWeight: 600,
@@ -74,14 +65,7 @@ export default function MetricTitle({
   return (
     <Grid item>
       { mainTitle && (
-        <div>
-          <Grid item xs={3}>
-            <Divider variant="middle" className={classes.hr} />
-          </Grid>
-          <Typography variant="h4" className={classes.title}>
-            {mainTitle}
-          </Typography>
-        </div>
+        <SectionTitle mainTitle={mainTitle} />
       )}
       <Grid container direction="row" alignItems="center">
         <Grid item className={classes.logo}>

--- a/client/web/src/organisms/shared/sub/SectionTitles.tsx
+++ b/client/web/src/organisms/shared/sub/SectionTitles.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Divider, Typography, Grid } from '@material-ui/core';
+
+const styles = makeStyles((theme) => ({
+  hr: {
+    margin: `${theme.spacing(1)}px 0px`,
+    backgroundColor: theme.palette.primary.main,
+    height: theme.spacing(0.5),
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 30,
+    margin: `${theme.spacing(1)}px 0px`,
+  },
+}));
+
+interface SectionTitleProps {
+  mainTitle: string;
+}
+
+export default function SectionTitle({ mainTitle }: SectionTitleProps): JSX.Element {
+  const classes = styles();
+
+  return (
+    <div>
+      <Grid item xs={2}>
+        <Divider variant="middle" className={classes.hr} />
+      </Grid>
+      <Typography variant="h4" className={classes.title}>
+        {mainTitle}
+      </Typography>
+    </div>
+  );
+}


### PR DESCRIPTION
## 공통사항
기 섹션 타이틀이 포함된 부모 컴포넌트로 분할하여 별도의 재사용가능한 컴포넌트로 분할.
대치될 기존의 섹션 타이틀 태그들의 스타일 값 삭제(사용하지 않기 때문)

### (1) 편집점 분석 탭
- 편집점 분석 섹션 타이틀 변환
- 편집점 분석 대시보드 섹션 타이틀 변환

### (2) 방송 분석 탭
제플린에 올라온 웹 페이지를 참고하니 방송별 비교, 기간대 기간 분석의 하단에 **채팅 발생수 평균 비교**가 있음
_=> 현재 개발된 내용에는 해당 사항이 없어서 추가함_
- 방송별 비교: **채팅 발생수 평균 비교 추가**, 방송별 비교 섹션 타이틀 변환
- 기간 추세 분석: 기간 추세 분석 섹션 타이틀 변환
- 기간대 기간 분석: **채팅 발생수 평균 비교 추가**, 기간대 기간 분석 섹션 타이틀 변환