### PR TITLE
[TP-SPRINT #2.1] 쌈마이 스낵바 수정

### DIFF
--- a/client/web/src/atoms/snackbar/ShowSnack.tsx
+++ b/client/web/src/atoms/snackbar/ShowSnack.tsx
@@ -1,24 +1,39 @@
 import React from 'react';
 import Alert from '@material-ui/lab/Alert';
-
+import Fade from '@material-ui/core/Fade';
 /*
  snack 함수 사용법 
  * snack은 최상위 context로 선언되어 있다.
-
  1. 사용할 컴포넌트에서 notistack의 context호출 함수 불러온다.
  > import { useSnackbar } from 'notistack';
- 
  2. alert의 위치와 형태 등을 warpping해둔 함수를 불러온다.
  > import ShowSnack from '../../../../atoms/snackbar/ShowSnack';
-
  3. 컴포넌트 내 에서 context를 호출한다.
  > const { enqueueSnackbar } = useSnackbar(); 
-
  4. 필요한 곳에서 함수(ShowSnack)를 수행하고, 인자에 (<메세지>, <타입>, enqueueSnackbar)를 입력하여 사용한다.
  > ShowSnack('기간을 다시 설정해 주세요', 'error', enqueueSnackbar);
 */
+
 const ShowSnack = (message: string, type: 'success' | 'info' | 'warning' | 'error',
-  enqueueSnackbar: (m: React.ReactNode, options?: any) => React.ReactText): React.ReactText => {
+  enqueueSnackbar: (m: React.ReactNode, options?: any) => React.ReactText,
+  location? : 'top'| 'bottom'): React.ReactText => {
+  // top, bottom을 추가하여 우선순위에 따라 위치를 변경할 수 있도록 한다.
+  // transition을 Fade로 변경한다.
+  const locationType = (location === 'top') ? {
+    anchorOrigin: {
+      vertical: 'top',
+      horizontal: 'right',
+    },
+    style: {
+      top: '158%',
+    },
+  } : {
+    anchorOrigin: {
+      vertical: 'bottom',
+      horizontal: 'left',
+    },
+  };
+
   const showSnack = enqueueSnackbar(message, {
     content: (key: string) => (
       <Alert
@@ -31,17 +46,11 @@ const ShowSnack = (message: string, type: 'success' | 'info' | 'warning' | 'erro
         {message}
       </Alert>
     ),
-    anchorOrigin: {
-      vertical: 'top',
-      horizontal: 'center',
-    },
-    style: {
-      left: '80%',
-      top: '450%',
-    },
+    // anchorOrigin,
+    TransitionComponent: Fade,
     autoHideDuration: 1500,
+    ...locationType,
   });
   return showSnack;
 };
-
 export default ShowSnack;


### PR DESCRIPTION
#### 스낵바 위치 수정 
> 이 전에 고려하였던 레이아웃의 변경으로 인하여 스낵바의 위치가 **쌈마이**가 되었다.

 - 위치를 오른쪽 상단이 아닌, 왼쪽 하단으로 변경
---

#### 스낵바 트랜지션 수정
> 이전에 사용하였던 위에서 내려오는 트랜지션이 **쌈마이** 였다.

- 트랜지션을 Fade를 사용하였다.
---
#### 스낵바 위치 옵션 추가

- 위치를 'top', 'bottom'의 옵션을 제공하여 하단의 스낵바가 어색한 경우, 사용할 수 있도록 제공한다. 
