### PR TITLE
[TP-SPRINT #2.2] 로그인 token 새로고침 로딩 시 로딩 화면 렌더링 및 token 필요 데이터 요청 제한

### DIFF
--- a/client/web/src/index.tsx
+++ b/client/web/src/index.tsx
@@ -44,9 +44,13 @@ function Index(): JSX.Element {
   });
   const truepointTheme: TruepointTheme = { ...THEME, handleThemeChange };
 
+  // *******************************************
+  // 로그인 관련 변수 및 함수 세트 가져오기
   const {
     user, accessToken, handleLogout, handleLogin,
+    loginLoading, handleLoginLoadingStart, handleLoginLoadingEnd,
   } = useLogin();
+
   /* subscribe 목록의 유저 전환 컨택스트 */
   const {
     currUser,
@@ -58,13 +62,13 @@ function Index(): JSX.Element {
   // axios-hooks configuration
   axios.interceptors.response.use(
     onResponseFulfilled,
-    makeResponseRejectedHandler(handleLogin),
+    makeResponseRejectedHandler(handleLogin, handleLoginLoadingStart, handleLoginLoadingEnd),
   );
   configure({ axios });
 
   // *******************************************
   // 자동로그인 훅. 반환값 없음. 해당 함수는 useLayoutEffect 만을 포함함.
-  useAutoLogin(user.userId, handleLogin);
+  useAutoLogin(user.userId, handleLogin, handleLoginLoadingStart, handleLoginLoadingEnd);
 
   return (
     <SnackbarProvider
@@ -76,7 +80,7 @@ function Index(): JSX.Element {
 
         {/* 로그인 여부 Context */}
         <AuthContext.Provider value={{
-          user, accessToken, handleLogin, handleLogout,
+          user, accessToken, handleLogin, handleLogout, loginLoading, handleLoginLoadingStart, handleLoginLoadingEnd,
         }}
         >
           <KakaoTalk />

--- a/client/web/src/pages/mypage/layouts/MypageLayout.tsx
+++ b/client/web/src/pages/mypage/layouts/MypageLayout.tsx
@@ -9,6 +9,8 @@ import Navbar from '../../../organisms/mypage/layouts/navbar/Navbar';
 import Sidebar from '../../../organisms/mypage/layouts/sidebar/Sidebar';
 import AppBar from '../../../organisms/shared/Appbar';
 import PageSizeAlert from '../../../organisms/mypage/alertbar/PageSizeAlert';
+import useAuthContext from '../../../utils/hooks/useAuthContext';
+import TruepointLogo from '../../../atoms/TruepointLogo';
 
 const UserDashboard = (): JSX.Element => {
   const classes = useLayoutStyles();
@@ -27,6 +29,21 @@ const UserDashboard = (): JSX.Element => {
   }
   function handleAlertClose() {
     setAlertOpen(false);
+  }
+
+  // token이 아직 없거나, refresh-token을 통해 새로운 access_token을 받아오고 있는 경우에 보여질 로딩 페이지
+  // 짧아서, 기존의 LoadingComponent는 사용이 불가한 듯 보인다. 그냥 로고만 띡 나오는 지금도 나쁘지는 않은 듯.
+  // @by dan, @when 2020. 11. 04.
+  const auth = useAuthContext();
+  if (!(!auth.loginLoading && auth.user.userId)) {
+    return (
+      <div style={{
+        display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh',
+      }}
+      >
+        <TruepointLogo />
+      </div>
+    );
   }
 
   return (

--- a/client/web/src/pages/mypage/layouts/MypageLoading.tsx
+++ b/client/web/src/pages/mypage/layouts/MypageLoading.tsx
@@ -1,0 +1,34 @@
+import { CircularProgress } from '@material-ui/core';
+// import useTheme from '@material-ui/core/styles/useTheme';
+import React from 'react';
+// import TruepointLogo from '../../../atoms/TruepointLogo';
+// import TruepointLogoLight from '../../../atoms/TruepointLogoLight';
+
+export default function MypageLoading(): JSX.Element {
+  // token이 아직 없거나, refresh-token을 통해 새로운 access_token을 받아오고 있는 경우에 보여질 로딩 페이지
+  // 짧아서, 기존의 LoadingComponent는 사용이 불가한 듯 보인다. 그냥 로고만 띡 나오는 지금도 나쁘지는 않은 듯.
+  // @by dan, @when 2020. 11. 04.
+
+  // Lottie + bodymovin 활용하여 after effect 애니메이션을 입힌 트루포인트 로고를 circular progress 대신 사용하는 것도 좋을 것 같다.
+  // https://airbnb.io/lottie/#/
+
+  // const theme = useTheme();
+  return (
+    <div style={{
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    }}
+    >
+      <CircularProgress />
+      {/* 로고 활용시 */}
+      {/* {theme.palette.type === 'dark' ? (
+        <TruepointLogoLight />
+      ) : (
+        <TruepointLogo />
+      )} */}
+    </div>
+  );
+}

--- a/client/web/src/utils/contexts/AuthContext.tsx
+++ b/client/web/src/utils/contexts/AuthContext.tsx
@@ -13,6 +13,9 @@ export interface AuthContextValue {
   accessToken?: string;
   handleLogin: (accessToken: string) => void;
   handleLogout: () => void;
+  loginLoading: boolean;
+  handleLoginLoadingStart: () => void;
+  handleLoginLoadingEnd: () => void;
 }
 
 const defaultUserValue = {
@@ -24,11 +27,15 @@ const AuthContext = React.createContext<AuthContextValue>({
   /* eslint-disable @typescript-eslint/no-empty-function */
   handleLogin: () => {},
   handleLogout: () => {},
+  loginLoading: false,
+  handleLoginLoadingStart: () => {},
+  handleLoginLoadingEnd: () => {},
   /* eslint-enable @typescript-eslint/no-empty-function */
 });
 
 export function useLogin(): AuthContextValue {
   const [user, setUser] = React.useState<LoginUser>(defaultUserValue);
+  const [loginLoading, setLoginLoading] = React.useState<boolean>(false);
   const [accessTokenState, setAccessToken] = React.useState<string>();
 
   function handleLogin(accessToken: string): void {
@@ -62,11 +69,22 @@ export function useLogin(): AuthContextValue {
       });
   }
 
+  // 로딩 제어 함수
+  function handleLoginLoadingStart() {
+    setLoginLoading(true);
+  }
+  function handleLoginLoadingEnd() {
+    setLoginLoading(false);
+  }
+
   return {
     user,
     accessToken: accessTokenState,
     handleLogin,
     handleLogout,
+    loginLoading,
+    handleLoginLoadingStart,
+    handleLoginLoadingEnd,
   };
 }
 

--- a/client/web/src/utils/hooks/useAutoLogin.tsx
+++ b/client/web/src/utils/hooks/useAutoLogin.tsx
@@ -2,17 +2,27 @@ import React from 'react';
 import axios from '../axios';
 
 export default function useAutoLogin(
-  userId: string | undefined, handleLogin: (s: string) => void,
+  userId: string | undefined,
+  handleLogin: (s: string) => void,
+  handleLoginLoadingStart: () => void,
+  handleLoginLoadingEnd: () => void,
 ): void {
   // *******************************************
   // 자동로그인 체크하여 유효한 refresh token이 있는 경우 자동 로그인
   React.useLayoutEffect(() => {
     if (!userId) {
       // console.log('refreshing!...');
+
+      // 로그인 로딩 start
+      handleLoginLoadingStart();
       axios.post('/auth/silent-refresh')
         .then((res) => {
           if (res.data) {
             handleLogin(res.data.access_token);
+
+            // 로그인 로딩 start
+            handleLoginLoadingEnd();
+
             // console.log('refreshed!...');
             // login, signup, find-id, find-pw인 경우 메인페이지로 이동
             if (['/login', '/signup', 'find-id', 'find-pw']
@@ -22,6 +32,8 @@ export default function useAutoLogin(
           }
         })
         .catch((err) => {
+          // 로그인 로딩 end
+          handleLoginLoadingEnd();
           if (err.status === 400
                || (err.response && err.response.status === 400)) {
             if (window.location.pathname !== '/') {

--- a/client/web/src/utils/interceptors/axiosInterceptor.ts
+++ b/client/web/src/utils/interceptors/axiosInterceptor.ts
@@ -8,12 +8,19 @@ export function onResponseFulfilled(request: AxiosResponse): AxiosResponse {
   return request;
 }
 
+// 에러 반환받았을 때의 Response interceptor
 export function makeResponseRejectedHandler(
   handleLogin: (token: string) => void,
+  handleLoginLoadingStart: () => void,
+  handleLoginLoadingEnd: () => void,
 ): (err: AxiosError) => any {
   function onResponseRejected(err: AxiosError): any {
     if (err.response && err.response.status === 401) {
       // Unauthorized Error 인 경우
+
+      // 로그인 로딩 start
+      handleLoginLoadingStart();
+
       return axios.post('/auth/silent-refresh')
         .then((res) => {
           const token = res.data.access_token;
@@ -22,11 +29,18 @@ export function makeResponseRejectedHandler(
           // 실패 요청을 재 요청
           const failedRequest = err.config;
           failedRequest.headers['cache-control'] = 'no-cache';
+
+          // 로그인 로딩 end
+          handleLoginLoadingEnd();
+
           return axios(failedRequest);
         })
         .catch(() => {
-          window.location.href = '/';
-          return Promise.reject(err); // 로그인으로 강제 이동
+          // 로그인 로딩 end
+          handleLoginLoadingEnd();
+
+          // window.location.href = '/';
+          Promise.reject(err); // 로그인으로 강제 이동
         });
     }
     return Promise.reject(err);


### PR DESCRIPTION
# 문제사항 (내용)

로그인 토큰 새로고침 요청에 대한 loading 변수가 없어,
토큰이 백엔드로부터 클라이언트로 전송되기 이전에,
필수적으로 토큰이 필요한 라우터에 요청하는 경우 로그인 되어있지 않은 것으로 인식하여 메인페이지로 이동하거나, 무한 루프 요청이 발생하는 버그가 생김.

+ AuthContext에 연동된 플랫폼 고유 아이디  정보를 추가

# 해결방안 및 해결 과정

로그인 토큰 새로고침 요청에 대한 loading State 생성 이후, 해당 state 를 참조하여

1. 기존 login 요청에 로딩 상태 값 추가
    - [x]  기존 login 요청에 로딩 상태 값 추가
2. 토큰 refresh에 로딩 상태 값 추가
    - [x]  토큰 refresh에 로딩 상태 값 추가
3. 로딩 중인 경우 로딩 화면 렌더링
    - [x]  로딩 화면 디자인 및 로딩 화면 생성 (현재 간단히 로고 화면만 생성 함.)
        - circularProgress 활용
    - [x]  로딩 화면 렌더링
    - [x]  02초의 timeout 이후 메인페이지로 이동되도록.
4. 토큰-새로고침 완료 이전, 페이지의 렌더링 제한
    - [x]  마이페이지의 사이드바, 네비바를 제외한 메인 패널 페이지 렌더링 제한