### PR TITLE
[TP-SPRINT #2.2] 방송분석 - 기간대기간 차트 렌더링 버그 수정 (1일 선택시 선,점 보이지 않는 버그)

### DIFF
--- a/client/web/src/organisms/mypage/graph/setLinearGraphComponent.ts
+++ b/client/web/src/organisms/mypage/graph/setLinearGraphComponent.ts
@@ -56,6 +56,8 @@ const setSeries = (
     series.tooltip.label.minHeight = 40;
     series.tooltip.label.textAlign = 'middle';
     series.tooltip.label.textValign = 'middle';
+    // Bullet 설정
+    series.bullets.push(new am4charts.CircleBullet());
   });
 };
 

--- a/client/web/src/organisms/mypage/graph/setLinearGraphComponent.ts
+++ b/client/web/src/organisms/mypage/graph/setLinearGraphComponent.ts
@@ -9,18 +9,21 @@ const metricSetting: any = {
     valueY: 'smileCount',
     tooltipText: '웃음 발생 수: [bold]{smileCount}[/]',
     color: am4core.color(graphColor.line),
+    unit: '회',
   },
   chat: {
     name: '채팅 발생 수',
     valueY: 'chatCount',
     tooltipText: '채팅 발생 수: [bold]{chatCount}[/]',
     color: am4core.color(graphColor.broad1),
+    unit: '회',
   },
   viewer: {
     name: '평균 시청자 수',
     valueY: 'viewer',
     tooltipText: '평균 시청자 수: [bold]{viewer}[/]',
     color: am4core.color(graphColor.broad2),
+    unit: '명',
   },
 };
 
@@ -42,7 +45,7 @@ const setSeries = (
     series.dataFields.valueY = setting.valueY;
     series.dataFields.dateX = 'date';
     series.name = setting.name;
-    series.tooltipText = setting.tooltipText;
+    series.tooltipText = `${setting.tooltipText}${setting.unit}`;
     series.strokeWidth = 2.5;
     series.tensionX = 0.8;
     series.tooltip.getFillFromObject = false;


### PR DESCRIPTION
기간 추세 분석에서 날짜를 1개 선택해도 기본적으로 2개 날짜를 띄워주게 해놓았지만 방송이 1개인 경우에는 차트가 잘 표시되지 않는다.

- 이유
    - amchart 차트에서 점 ( Bullet )을 설정해두지 않음. 생성함.
    - [x] Bullet 생성
    - 툴팁에 "회" 추가
    - [x] 툴팁에 "회" 추가
        - 시청자 수 인경우 "명"