### PR TITLE
[TP-SPRINT #3.1] 비밀글 - 글 확인 불가 버그 + 비밀글 수정시 비밀글체크 항상 false인 현상 수정

### DIFF
--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureDetail.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureDetail.tsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles((theme) => ({
   },
   titleText: { textTransform: 'none', fontWeight: 'bold' },
   contentsText: { padding: theme.spacing(4), minHeight: 300 },
+  secretText: {
+    display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', minHeight: 300,
+  },
   buttonSet: {
     padding: `${theme.spacing(4)}px 0px ${theme.spacing(2)}px`,
     display: 'flex',
@@ -108,17 +111,10 @@ export default function FeatureDetail({
     }
   };
 
-  const rejectPage = (): JSX.Element => {
-    ShowSnack('비밀글은 작성자만 볼 수 있습니다.', 'error', enqueueSnackbar);
-    window.location.replace('/feature-suggestion');
-    return (
-      <div />
-    );
-  };
-
-  const suggestionDetail = (): JSX.Element => (
+  return (
     <div>
       <Paper component="article" ref={paperRef}>
+        {/* 제목 섹션 */}
         <div className={classes.title}>
           <div>
             <Typography component="div" variant="h6" className={classes.titleText}>
@@ -180,9 +176,26 @@ export default function FeatureDetail({
             </Button>
           </div>
         )}
+
+        {/* 내용 섹션 */}
         <div className={classes.contentsText}>
           <div className={classes.markdown}>
-            <Viewer initialValue={currentSuggestion.content} />
+            {/* 비밀글 + 자신이 작성한 글이 아닌 경우 비밀글 처리 */}
+            {currentSuggestion.isLock && currentSuggestion.author.userId !== authContext.user.userId ? (
+              <div className={classes.secretText}>
+                <Typography>비밀글의 경우 본인만 확인할 수 있습니다.</Typography>
+                <Button
+                  className={classes.listButton}
+                  size="large"
+                  variant="outlined"
+                  onClick={onBackClick}
+                >
+                  목록
+                </Button>
+              </div>
+            ) : ( // 비밀글이 아닌경우 또는 비밀글 + 자신이 작성한 글인 경우 Viewer 렌더링
+              <Viewer initialValue={currentSuggestion.content} />
+            )}
           </div>
         </div>
       </Paper>
@@ -277,28 +290,6 @@ export default function FeatureDetail({
           <KeyboardArrowRight />
         </Button>
       </div>
-    </div>
-  );
-
-  return (
-    <div>
-      {currentSuggestion.isLock ? (
-        <div>
-          {currentSuggestion.author.userId !== authContext.user.userId ? (
-            <div>
-              {rejectPage()}
-            </div>
-          ) : (
-            <div>
-              {suggestionDetail()}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div>
-          {suggestionDetail()}
-        </div>
-      )}
     </div>
   );
 }

--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureWriteForm.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureWriteForm.tsx
@@ -122,8 +122,10 @@ export default function FeatureWriteForm(): JSX.Element {
   };
 
   React.useEffect(() => {
-    if (param && param.id) {
+    if (param && param.id) { // 글 수정하기 작업시
+      // 비밀글 여부를 기존 글의 비밀글 여부로 변경
       setFeatureLock(Boolean(location.state[0].isLock));
+      // 글 제목, 카테고리를 기존 글의 그것으로 변경
       setFeatureSource({
         ...featureSource,
         title: location.state[0].title,

--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureWriteForm.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureWriteForm.tsx
@@ -123,6 +123,7 @@ export default function FeatureWriteForm(): JSX.Element {
 
   React.useEffect(() => {
     if (param && param.id) {
+      setFeatureLock(Boolean(location.state[0].isLock));
       setFeatureSource({
         ...featureSource,
         title: location.state[0].title,

--- a/client/web/src/pages/mainpage/FeatureSuggestion.tsx
+++ b/client/web/src/pages/mainpage/FeatureSuggestion.tsx
@@ -2,7 +2,9 @@ import React, { useEffect } from 'react';
 import classnames from 'classnames';
 import useAxios from 'axios-hooks';
 import { makeStyles } from '@material-ui/core/styles';
-import { Typography, Chip } from '@material-ui/core';
+import {
+  Typography, Chip, CircularProgress, Paper,
+} from '@material-ui/core';
 import { useHistory, useParams } from 'react-router-dom';
 import { FeatureSuggestion } from '@truepoint/shared/dist/interfaces/FeatureSuggestion.interface';
 import ProductHero from '../../organisms/mainpage/shared/ProductHero';
@@ -33,6 +35,9 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'flex-end',
     alignContent: 'flex-end',
+  },
+  detailLoading: {
+    height: 300, display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column',
   },
   tableContainer: { marginTop: theme.spacing(1) },
 }));
@@ -88,6 +93,11 @@ export default function FeatureSuggestionPage(): JSX.Element {
           <Typography variant="h4">기능제안</Typography>
 
           {/* 기능제안 개별 보기 */}
+          {selectedSuggestionId && loading && (
+            <Paper elevation={0} className={classes.detailLoading}>
+              <CircularProgress />
+            </Paper>
+          )}
           {selectedSuggestionId && !loading && data && (
             <div className={classes.contents}>
               <FeatureDetail


### PR DESCRIPTION
### 문제사항 (내용)

- 도메인 입력창에 feature-suggestion/read/40 과 같이 입력하면 타인이 작성한 비밀글이라도 글을 열람할 수 있으므로, 밖으로 튕기도록 했으나, 자신이 작성한 글임에도 튕기는 현상 발생
- 일감 진행 중 찾은 버그
    - 비밀글 상태인 글을 수정 시, 비밀글 체크 기본값이 언제나 false로 되어있어 다시 비밀글 체크를 하지 않으면 비밀글이 풀림.

### 해결방안

1. 튕기게 하지 말고, "비밀글은 작성자만 확인할수있습니다" 표시 추가 및 목록으로 돌아가기 버튼 추가
    - 이 과정에서, 볼수있는 권한이 있는지 체크 하는 방법
    ⇒ 비밀글아닌 경우 → 모두 보기
    ⇒ 비밀글인 경우 → 작성자와 본인이 동일인인지 확인 → 동일인이라면 글 렌더링
    ⇒ 비밀글인 경우 → 작성자와 본인이 동일인인지 확인 → 동일인 아니라면 → "비밀글은 작성자만 확인할수있습니다" 표시 추가 및 목록으로 돌아가기 버튼 렌더링
2. [수정] 클릭 시, 비밀글 여부를 기존 글의 상태에서 가져와 설정하도록 변경