### PR TITLE
[TP-SPRINT #3.1] 다크모드 - 스낵바 렌더링 시 뒷배경 색상 제거 버그

### DIFF
--- a/client/web/src/index.tsx
+++ b/client/web/src/index.tsx
@@ -72,12 +72,10 @@ function Index(): JSX.Element {
   useAutoLogin(user.userId, handleLogin, handleLoginLoadingStart, handleLoginLoadingEnd);
 
   return (
-    <SnackbarProvider
-      maxSnack={1}
-      preventDuplicate
-    >
-      <ThemeProvider<TruepointTheme> theme={truepointTheme}>
-        <CssBaseline />
+    <ThemeProvider<TruepointTheme> theme={truepointTheme}>
+      <CssBaseline />
+
+      <SnackbarProvider maxSnack={1} preventDuplicate>
 
         {/* 로그인 여부 Context */}
         <AuthContext.Provider value={{
@@ -117,8 +115,8 @@ function Index(): JSX.Element {
           </BrowserRouter>
           {/* </SubscribeContext.Provider> */}
         </AuthContext.Provider>
-      </ThemeProvider>
-    </SnackbarProvider>
+      </SnackbarProvider>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
### 문제사항
- ThemeProvider 와 SnackbarProvider 포함관계 확인.
( theme 보다 위에 있어서 생긴 문제일 가능성이 높다. )
- 다크테마에서만 존재하는 버그

### 해결방안

- [x]  ThemeProvider 내부에 SnackbarProvider를 포함시켜 동일한 Theme를 참조하도록 한다.