### PR TITLE
[TP-SPRINT #3.1] 동일 아이디 중복 연동 제한 기능 추가

### DIFF
--- a/client/web/src/organisms/mypage/my-office/ManagePlatformLink.tsx
+++ b/client/web/src/organisms/mypage/my-office/ManagePlatformLink.tsx
@@ -10,6 +10,7 @@ import ShowSnack from '../../../atoms/snackbar/ShowSnack';
 import useAuthContext from '../../../utils/hooks/useAuthContext';
 import useDialog from '../../../utils/hooks/useDialog';
 import PlatformDeleteConfirmDialog from './sub/PlatformDeleteConfirmDialog';
+import { getApiHost } from '../../../utils/getApiHost';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -58,14 +59,9 @@ export default function ManagePlatformLink({
   // *******************************
   // 연동 요청
   function handleLinkStart(platform: Platform) {
-    let host = 'http://localhost:3000';
     let params = platform;
     if (platform === 'afreeca') params += `?__userId=${auth.user.userId}`;
-
-    if (process.env.NODE_ENV === 'production') {
-      host = 'https://api.mytruepoint.com';
-    }
-    window.location.href = `${host}/auth/${params}`;
+    window.location.href = `${getApiHost()}/auth/${params}`;
   }
 
   // *******************************

--- a/client/web/src/pages/mypage/my-office/Settings.tsx
+++ b/client/web/src/pages/mypage/my-office/Settings.tsx
@@ -20,6 +20,7 @@ import SectionTitle from '../../../organisms/shared/sub/SectionTitles';
 import ShowSnack from '../../../atoms/snackbar/ShowSnack';
 import DeleteUser from '../../../organisms/mypage/my-office/DeleteUser';
 import transformIdToAsterisk from '../../../utils/transformAsterisk';
+import getJosa from '../../../utils/getJosa';
 
 const useStyles = makeStyles((theme) => ({
   container: { padding: theme.spacing(6) },
@@ -72,7 +73,7 @@ export default function Settings(): JSX.Element {
             const { platformUserName, userId } = data;
             // 연동하고자 하는 플랫폼계정이 다른 유저에게 연동되어 있는 경우
             setAlreadyLinkedWithOther(
-              `현재 연동하고자 하는 ${capitalize(params.platform)} 계정 "${platformUserName}" 은(는)
+              `현재 연동하고자 하는 ${capitalize(params.platform)} 계정 ${`"${platformUserName}"${getJosa(platformUserName, '은/는')}`}
               다른 유저 "${transformIdToAsterisk(userId, 1.8)}" 에게 연동되어있습니다.`,
             );
           }

--- a/client/web/src/utils/axios.ts
+++ b/client/web/src/utils/axios.ts
@@ -1,22 +1,5 @@
 import Axios from 'axios';
-
-function getApiHost(): string {
-  let apihost = '';
-
-  switch (process.env.REACT_APP_NODE_ENV) {
-    case 'test':
-      apihost = 'https://test-api.mytruepoint.com';
-      break;
-    case 'production':
-      apihost = 'https://api.mytruepoint.com';
-      break;
-    case 'development':
-    default:
-      apihost = 'http://localhost:3000';
-      break;
-  }
-  return apihost;
-}
+import { getApiHost } from './getApiHost';
 
 const axios = Axios.create({
   baseURL: getApiHost(),

--- a/client/web/src/utils/getApiHost.ts
+++ b/client/web/src/utils/getApiHost.ts
@@ -1,0 +1,17 @@
+export function getApiHost(): string {
+  let apihost = '';
+
+  switch (process.env.REACT_APP_NODE_ENV) {
+    case 'test':
+      apihost = 'https://test-api.mytruepoint.com';
+      break;
+    case 'production':
+      apihost = 'https://api.mytruepoint.com';
+      break;
+    case 'development':
+    default:
+      apihost = 'http://localhost:3000';
+      break;
+  }
+  return apihost;
+}

--- a/client/web/src/utils/getJosa.ts
+++ b/client/web/src/utils/getJosa.ts
@@ -1,0 +1,49 @@
+export type JosaType = '을/를' | '은/는' | '이/가' | '과/와' | '으로/로';
+
+function checkJongSung(wordCode: number): boolean {
+  return (wordCode - 0xAC00) % 28 > 0;
+}
+
+export default function getJosa(word: string, josaType: JosaType): string {
+  const strCode = word.charCodeAt(word.length - 1);
+  // 한글이 아닌 경우
+  if (strCode < 0xAC00 || strCode > 0xD7A3) {
+    return word;
+  }
+  switch (josaType) {
+    case '을/를':
+      return checkJongSung(strCode) ? '을' : '를';
+    case '은/는':
+      return checkJongSung(strCode) ? '은' : '는';
+    case '이/가':
+      return checkJongSung(strCode) ? '이' : '가';
+    case '과/와':
+      return checkJongSung(strCode) ? '과' : '와';
+    case '으로/로':
+      return checkJongSung(strCode) ? '으로' : '로';
+    default:
+      throw new Error('getJosa 함수는 josaType 파라미터가 필요합니다.');
+  }
+}
+
+export function getJosaWithWord(word: string, josaType: JosaType): string {
+  const strCode = word.charCodeAt(word.length - 1);
+  // 한글이 아닌 경우
+  if (strCode < 0xAC00 || strCode > 0xD7A3) {
+    return word;
+  }
+  switch (josaType) {
+    case '을/를':
+      return checkJongSung(strCode) ? `${word}을` : `${word}를`;
+    case '은/는':
+      return checkJongSung(strCode) ? `${word}은` : `${word}는`;
+    case '이/가':
+      return checkJongSung(strCode) ? `${word}이` : `${word}가`;
+    case '과/와':
+      return checkJongSung(strCode) ? `${word}과` : `${word}와`;
+    case '으로/로':
+      return checkJongSung(strCode) ? `${word}으로` : `${word}로`;
+    default:
+      throw new Error('withJosa 함수는 josaType 파라미터가 필요합니다.');
+  }
+}

--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -19,9 +19,9 @@ import { PlatformYoutubeEntity } from '../users/entities/platformYoutube.entity'
 import { YoutubeLinkGuard } from '../../guards/youtube-link.guard';
 import { TwitchLinkGuard } from '../../guards/twitch-link.guard';
 import { AfreecaPreLinker } from './strategies/afreeca.linker';
-import { TwitchLinkExceptionFilter } from '../../filters/twitch-link.filter';
-import { YoutubeLinkExceptionFilter } from '../../filters/youtube-link.filter';
-import { AfreecaLinkExceptionFilter } from '../../filters/afreeca-link.filter';
+import { TwitchLinkExceptionFilter } from './filters/twitch-link.filter';
+import { YoutubeLinkExceptionFilter } from './filters/youtube-link.filter';
+import { AfreecaLinkExceptionFilter } from './filters/afreeca-link.filter';
 import getFrontHost from '../../utils/getFrontHost';
 
 @Controller('auth')
@@ -235,13 +235,16 @@ export class AuthController {
     } = await this.afreecaLinker.getTokens(afreecaAuthorizationCode as string);
 
     // link with truepoint user
-    this.afreecaLinker.link(refreshToken, userId)
+    await this.afreecaLinker.link(refreshToken, userId)
       .then(() => {
         // settings뒤에 / 꼭 추가. amplify redirect 관련한 일종의 버그 있음.
         // https://github.com/aws-amplify/amplify-console/issues/97
 
         // 실제 아프리카 유저 아이디를 들고올 수 있을 때, id, platform 쿼리스트링 추가
         res.redirect(`${getFrontHost()}/mypage/my-office/settings/`); // ?id=${afreecaId}&platform=afreeca
+      })
+      .catch((err) => {
+        throw new Error(`${err.message}&platform=afreeca`);
       });
   }
 }

--- a/server/src/resources/auth/filters/afreeca-link.filter.ts
+++ b/server/src/resources/auth/filters/afreeca-link.filter.ts
@@ -1,19 +1,18 @@
 import {
   ArgumentsHost, Catch, ExceptionFilter,
 } from '@nestjs/common';
-import { Request, Response } from 'express';
-import getFrontHost from '../utils/getFrontHost';
+import { Response } from 'express';
+import getFrontHost from '../../../utils/getFrontHost';
 
 @Catch()
-export class TwitchLinkExceptionFilter implements ExceptionFilter {
+export class AfreecaLinkExceptionFilter implements ExceptionFilter {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   catch(exception: any, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
-    const request = ctx.getRequest<Request>();
     const response = ctx.getResponse<Response>();
 
     response.redirect(
-      `${getFrontHost()}/mypage/my-office/settings?${request.url.split('?')[1]}`,
+      `${getFrontHost()}/mypage/my-office/settings?error=${exception.message}`,
     );
   }
 }

--- a/server/src/resources/auth/filters/twitch-link.filter.ts
+++ b/server/src/resources/auth/filters/twitch-link.filter.ts
@@ -2,10 +2,10 @@ import {
   ArgumentsHost, Catch, ExceptionFilter,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import getFrontHost from '../utils/getFrontHost';
+import getFrontHost from '../../../utils/getFrontHost';
 
 @Catch()
-export class YoutubeLinkExceptionFilter implements ExceptionFilter {
+export class TwitchLinkExceptionFilter implements ExceptionFilter {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   catch(exception: any, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();

--- a/server/src/resources/auth/filters/youtube-link.filter.ts
+++ b/server/src/resources/auth/filters/youtube-link.filter.ts
@@ -1,18 +1,19 @@
 import {
   ArgumentsHost, Catch, ExceptionFilter,
 } from '@nestjs/common';
-import { Response } from 'express';
-import getFrontHost from '../utils/getFrontHost';
+import { Request, Response } from 'express';
+import getFrontHost from '../../../utils/getFrontHost';
 
 @Catch()
-export class AfreecaLinkExceptionFilter implements ExceptionFilter {
+export class YoutubeLinkExceptionFilter implements ExceptionFilter {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   catch(exception: any, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
     const response = ctx.getResponse<Response>();
 
     response.redirect(
-      `${getFrontHost()}/mypage/my-office/settings?error=${exception.message}`,
+      `${getFrontHost()}/mypage/my-office/settings?${request.url.split('?')[1]}`,
     );
   }
 }

--- a/server/src/resources/auth/strategies/afreeca.linker.ts
+++ b/server/src/resources/auth/strategies/afreeca.linker.ts
@@ -59,7 +59,7 @@ export class AfreecaPreLinker {
       }
       return { refreshToken, accessToken };
     } catch (e) {
-      console.error(e);
+      console.error('An Error occurred during getting refreshtoken from afreecatv', e.message);
       throw new InternalServerErrorException('An Error occurred during getting refreshtoken from afreecatv');
     }
   }
@@ -72,14 +72,9 @@ export class AfreecaPreLinker {
    * @param userId 해당 유저 Truepoint ID
    */
   async link(refreshToken: string, userId: string): Promise<void> {
-    try {
-      await this.usersService.linkAfreeca({
-        refreshToken, afreecaId: userId,
-      });
-      await this.usersService.linkUserToPlatform(userId, 'afreeca', userId);
-    } catch (e) {
-      console.error(e);
-      throw new InternalServerErrorException('An Error occurred during inserting afreecatv link data');
-    }
+    await this.usersService.linkAfreeca({
+      refreshToken, afreecaId: userId,
+    });
+    await this.usersService.linkUserToPlatform(userId, 'afreeca', userId);
   }
 }

--- a/server/src/resources/users/users.controller.ts
+++ b/server/src/resources/users/users.controller.ts
@@ -58,6 +58,11 @@ export class UsersController {
     return this.usersService.findOneProfileImage(req.user.userId);
   }
 
+  /**
+   * 연동된 플랫폼 닉네임/채널명을 열람 GET 컨트롤러
+   * @param req user 정보를 포함한 리퀘스트 객체
+   * @param userId 연동된 플랫폼 닉네임/채널명을 열람하고자 하는 유저 아이디
+   */
   @Get('platform-names')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(ClassSerializerInterceptor)

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -1,13 +1,13 @@
 import bcrypt from 'bcrypt';
 import {
-  Injectable, HttpException, HttpStatus, BadRequestException, InternalServerErrorException,
+  Injectable, HttpException, HttpStatus, BadRequestException, InternalServerErrorException, ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UpdateUserDto } from '@truepoint/shared/dist/dto/users/updateUser.dto';
 import { ProfileImages } from '@truepoint/shared/dist/res/ProfileImages.interface';
 import { ChannelNames } from '@truepoint/shared/dist/res/ChannelNames.interface';
-import { LinkPlatformRes } from '@truepoint/shared/dist/res/LinkPlatformRes.interface';
+import { LinkPlatformError, LinkPlatformRes } from '@truepoint/shared/dist/res/LinkPlatformRes.interface';
 import { UserEntity } from './entities/user.entity';
 import { UserTokenEntity } from './entities/userToken.entity';
 import { SubscribeEntity } from './entities/subscribe.entity';
@@ -306,11 +306,29 @@ export class UsersService {
     // platformTwitch, platformYoutube, platformAfreeca 등을 체크한 후 있으면 그 때 넣도록 처리.
     switch (platform) {
       case 'twitch': {
-        // 이미 적재된 경우 다시 적재하지 않음.
-        if (targetUser.twitchId === platformId) return 'already-linked';
+        // 연동platform 정보 가져오기
         const linkedInfo = await this.twitchRepository.findOne(platformId);
-        if (linkedInfo) targetUser[`${platform}Id`] = platformId;
-        else {
+
+        // 이미 나에게 연동된 경우 다시 반복하지 않음.
+        if (targetUser.twitchId === platformId) return 'already-linked';
+
+        if (linkedInfo) {
+          // 해당 Platform 아이디가 이미 다른 유저에게 연동된 Platform 계정인지 확인하여 이미 연동된 계정이 있는 경우 에러 처리
+          const alreadyLinkedTwitchId = await this.usersRepository.findOne({ twitchId: platformId });
+          if (alreadyLinkedTwitchId) {
+            // 해당 TwitchId 계정이 이미 다른 유저에게 연동된 TwitchId 계정.
+            const errMsg: LinkPlatformError = {
+              message: 'linked-with-other',
+              data: {
+                userId: alreadyLinkedTwitchId.userId,
+                platformUserName: (await this.twitchRepository.findOne(platformId)).twitchChannelName,
+              },
+            };
+            throw new ForbiddenException(errMsg);
+          }
+          // 실제 연동 가능 -> 연동 처리
+          targetUser[`${platform}Id`] = platformId;
+        } else {
           throw new InternalServerErrorException(
             'An error occurred during linking platform: there is no platform information',
           );
@@ -318,11 +336,30 @@ export class UsersService {
         break;
       }
       case 'youtube': {
-        // 이미 적재된 경우 다시 적재하지 않음.
-        if (targetUser.youtubeId === platformId) return 'already-linked';
+        // 연동platform 정보 가져오기
         const linkedInfo = await this.youtubeRepository.findOne(platformId);
-        if (linkedInfo) targetUser[`${platform}Id`] = platformId;
-        else {
+
+        // 이미 나에게 연동된 경우 다시 반복하지 않음.
+        if (targetUser.youtubeId === platformId) return 'already-linked';
+
+        // 해당 Platform 아이디가 이미 다른 유저에게 연동된 Platform 계정인지 확인
+        if (linkedInfo) {
+          const alreadyLinkedYoutubeId = await this.usersRepository.findOne({ youtubeId: platformId });
+          if (alreadyLinkedYoutubeId) {
+            // 해당 Youtube 계정이 이미 다른 유저에게 연동된 Youtube 계정.
+            const errMsg: LinkPlatformError = {
+              message: 'linked-with-other',
+              data: {
+                userId: alreadyLinkedYoutubeId.userId,
+                platformUserName: (await this.youtubeRepository.findOne(platformId)).youtubeTitle,
+              },
+            };
+            throw new ForbiddenException(errMsg);
+          }
+
+          // 실제 연동 가능 -> 연동 처리
+          targetUser[`${platform}Id`] = platformId;
+        } else {
           throw new InternalServerErrorException(
             'An error occurred during linking platform: there is no platform information',
           );
@@ -330,16 +367,35 @@ export class UsersService {
         break;
       }
       case 'afreeca': {
-        // 이미 적재된 경우 다시 적재하지 않음.
-        if (targetUser.afreecaId === platformId) return 'already-linked';
+        // 연동platform 정보 가져오기
         const linkedInfo = await this.afreecaRepository.findOne(platformId);
-        if (linkedInfo) targetUser[`${platform}Id`] = platformId;
-        else {
+
+        // 이미 나에게 연동된 경우 다시 반복하지 않음.
+        if (targetUser.afreecaId === platformId) return 'already-linked';
+
+        // 해당 Platform 아이디가 이미 다른 유저에게 연동된 Platform 계정인지 확인
+        if (linkedInfo) {
+          const alreadyLinkedAfreecaId = await this.usersRepository.findOne({ afreecaId: platformId });
+          if (alreadyLinkedAfreecaId) {
+            // 해당 Youtube 계정이 이미 다른 유저에게 연동된 Youtube 계정.
+            const errMsg: LinkPlatformError = {
+              message: 'linked-with-other',
+              data: {
+                userId: alreadyLinkedAfreecaId.userId,
+                platformUserName: (await this.afreecaRepository.findOne(platformId)).afreecaStreamerName,
+              },
+            };
+            throw new ForbiddenException(errMsg);
+          }
+
+          // 실제 연동 가능 -> 연동 처리
+          targetUser[`${platform}Id`] = platformId;
+          break;
+        } else {
           throw new InternalServerErrorException(
             'An error occurred during linking platform: there is no platform information',
           );
         }
-        break;
       }
       default: throw new BadRequestException('platform must be one of "twitch" | "afreeca" | "youtube"');
     }

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -321,7 +321,7 @@ export class UsersService {
               message: 'linked-with-other',
               data: {
                 userId: alreadyLinkedTwitchId.userId,
-                platformUserName: (await this.twitchRepository.findOne(platformId)).twitchChannelName,
+                platformUserName: linkedInfo.twitchChannelName,
               },
             };
             throw new ForbiddenException(errMsg);
@@ -351,7 +351,7 @@ export class UsersService {
               message: 'linked-with-other',
               data: {
                 userId: alreadyLinkedYoutubeId.userId,
-                platformUserName: (await this.youtubeRepository.findOne(platformId)).youtubeTitle,
+                platformUserName: linkedInfo.youtubeTitle,
               },
             };
             throw new ForbiddenException(errMsg);
@@ -382,7 +382,7 @@ export class UsersService {
               message: 'linked-with-other',
               data: {
                 userId: alreadyLinkedAfreecaId.userId,
-                platformUserName: (await this.afreecaRepository.findOne(platformId)).afreecaStreamerName,
+                platformUserName: linkedInfo.afreecaStreamerName,
               },
             };
             throw new ForbiddenException(errMsg);
@@ -475,25 +475,33 @@ export class UsersService {
   }
 
   // ****************** 유튜브 *******************
-  // 트위치 연동 데이터 적재 ( PlatformTwitch 테이블 )
+  // 유튜부 연동 데이터 적재 ( PlatformYoutube 테이블 )
   async linkYoutube(data: PlatformYoutubeEntity): Promise<PlatformYoutubeEntity> {
     const alreadyLinked = await this.youtubeRepository.findOne({
       googleId: data.googleId, youtubeId: data.youtubeId,
     });
     if (alreadyLinked) {
       // 이미 해당 youtube 유저와 연동된 아이디가 있는 경우 "업데이트"
-
+      this.youtubeRepository.update([
+        'googleId', 'googleName', 'googleEmail',
+        'googleLogo', 'youtubeId', 'youtubeTitle', 'youtubeLogo',
+      ], data);
     }
     return this.youtubeRepository.save(data);
   }
 
-  // ****************** 유튜브 *******************
-  // 트위치 연동 데이터 적재 ( PlatformTwitch 테이블 )
+  // ****************** 아프리카 *******************
+  // 아프리카 연동 데이터 적재 ( PlatformAfreeca 테이블 )
   async linkAfreeca(data: PlatformAfreecaEntity): Promise<PlatformAfreecaEntity> {
     const alreadyLinked = await this.afreecaRepository.findOne(data.afreecaId);
     if (alreadyLinked) {
-      // 이미 해당 youtube 유저와 연동된 아이디가 있는 경우 "업데이트"
-
+      // 이미 해당 afreeca 유저와 연동된 아이디가 있는 경우 "업데이트"
+      this.afreecaRepository.update([
+        'afreecaId',
+        'refreshToken',
+        'afreecaStreamerName',
+        'logo',
+      ], data);
     }
     return this.afreecaRepository.save(data);
   }

--- a/shared/res/LinkPlatformRes.interface.ts
+++ b/shared/res/LinkPlatformRes.interface.ts
@@ -2,3 +2,11 @@ import { User } from '../interfaces/User.interface';
 
 export type AlreadyLinked = 'already-linked';
 export type LinkPlatformRes = User | AlreadyLinked;
+
+export interface LinkPlatformError {
+  message: string;
+  data: {
+    platformUserName: string;
+    userId: string;
+  }
+}


### PR DESCRIPTION
# 문제 사항(내용)

연동 하려는 (트,유,아) 계정이 이미 다른 TP 유저에게 연동된 경우
다른 계정에 연동된 아이디이므로 연동 불가하여야 하며, 그것을 유저에게 알려야한다.

# 해결방안

현재 연동하려는 (아,트,유) 0000계정은 다른 TP 계정에 연동된 계정으로 연동이 불가합니다. 문의 부탁드립니다.

<img width="600px" height="400px" src="https://user-images.githubusercontent.com/43170520/101302251-6a933880-387e-11eb-84d6-6f58bcaedf7a.png"></img>

→ 연동된 유저 이름 마스킹 처리하여 보여주기

# 체크리스트

- [x]  기능 추가
- [x]  제한 테스트
    - [x]  아프리카
    - [x]  트위치
    - [x]  유튜브
- [x]  연동 테스트
    - [x]  아프리카
    - [x]  트위치
    - [x]  유튜브
- [ ]  문의하기 버튼 카카오톡 채널로 연결 필요