### PR TITLE
[TP-SPRINT #3.1]기능제안 목록 렉걸리는 현상 수정 → 모든글 불러오지 않도록

### DIFF
--- a/client/web/src/atoms/Dialog/Dialog.tsx
+++ b/client/web/src/atoms/Dialog/Dialog.tsx
@@ -83,6 +83,7 @@ function CustomDialog({
     <Dialog
       onClose={onClose}
       TransitionComponent={Transition}
+      disableScrollLock
       open={open}
       {...rest}
     >

--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureDetail.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureDetail.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useRef } from 'react';
+import classnames from 'classnames';
 import useAxios from 'axios-hooks';
 import { makeStyles } from '@material-ui/core/styles';
 import {
-  Button, Paper, Typography, Chip,
+  Button, Paper, Typography, Chip, CircularProgress,
 } from '@material-ui/core';
 import {
   Create, Delete, KeyboardArrowLeft, KeyboardArrowRight,
 } from '@material-ui/icons';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { FeatureSuggestion } from '@truepoint/shared/dist/interfaces/FeatureSuggestion.interface';
 // import Divider from '@material-ui/core/Divider';
 // import Card from '../../../atoms/Card/Card';
@@ -21,6 +22,8 @@ import FeatureReplyInput from './sub/FeatureReplyInput';
 import FeatureReply from './sub/FeatureReply';
 // attoms snackbar
 import ShowSnack from '../../../atoms/snackbar/ShowSnack';
+import CustomDialog from '../../../atoms/Dialog/Dialog';
+import useDialog from '../../../utils/hooks/useDialog';
 
 const useStyles = makeStyles((theme) => ({
   markdown: { fontSize: theme.typography.body1.fontSize },
@@ -33,6 +36,7 @@ const useStyles = makeStyles((theme) => ({
   },
   titleText: { textTransform: 'none', fontWeight: 'bold' },
   contentsText: { padding: theme.spacing(4), minHeight: 300 },
+  loadingWrapper: { display: 'flex', justifyContent: 'center', alignItems: 'center' },
   secretText: {
     display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', minHeight: 300,
   },
@@ -57,7 +61,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export interface FeatureDetailProps {
-  data: FeatureSuggestion[];
+  data: Omit<FeatureSuggestion, 'content' | 'replies'>[];
   selectedSuggestionId: string;
   onBackClick: () => void;
   onOtherFeatureClick: (num: number) => void;
@@ -68,8 +72,18 @@ export default function FeatureDetail({
   onOtherFeatureClick, refetch,
 }: FeatureDetailProps): JSX.Element {
   const classes = useStyles();
+  const history = useHistory();
   const authContext = useAuthContext();
   const { enqueueSnackbar } = useSnackbar();
+
+  // ******************************************************************
+  // 개별 세부 데이터 요청 (답변 목록 및 개별 답변 정보, 내용 정보를 포함하는 데이터 요청)
+  const [{ loading, data: featureDetailData }, doGetRequest] = useAxios<FeatureSuggestion>(
+    { url: '/feature-suggestion', method: 'get', params: { id: selectedSuggestionId } },
+  );
+  useEffect(() => {
+    doGetRequest();
+  }, [selectedSuggestionId, doGetRequest]);
 
   const [, deleteRequest] = useAxios(
     { url: '/feature-suggestion', method: 'delete' }, { manual: true },
@@ -77,22 +91,16 @@ export default function FeatureDetail({
   // length of title to render on Next/Previous button
   const TITLE_LENGTH = 15;
 
-  // Current Feature
-  const currentSuggestion = data.find((d) => d.suggestionId === Number(selectedSuggestionId))!; // 선택된 기능제안 글은 언제나 있으므로, type assertion.
-  const currentSuggestionIndex = data.findIndex((d) => d.suggestionId === Number(selectedSuggestionId));
+  // ******************************************************************
+  // (내용/답변목록을 제외한) 기능제안 목록 중, 현재 기능제안 인덱스와 해당 데이터
+  const currentIndex = data.findIndex((d) => d.suggestionId === Number(selectedSuggestionId));
+  const currentFeatureData = data[currentIndex];
+
   // Previous Feature
-  const previousFeature = data[currentSuggestionIndex - 1];
+  const previousFeature = data[currentIndex - 1];
 
   // Next Feature
-  const nextFeature = data[currentSuggestionIndex + 1];
-
-  const doDelete = () => {
-    const doConfirm = window.confirm('삭제 하시겠습니까?');
-    if (doConfirm) {
-      deleteRequest({ params: { data: currentSuggestion.suggestionId } });
-      window.location.replace('/feature-suggestion');
-    }
-  };
+  const nextFeature = data[currentIndex + 1];
 
   // 스크롤 상단으로
   const paperRef = useRef<HTMLDivElement>();
@@ -101,6 +109,20 @@ export default function FeatureDetail({
       window.scrollTo(0, paperRef.current.scrollHeight + 100);
     }
   });
+
+  const confirmDialog = useDialog();
+  // ******************************************************************
+  // 삭제
+  const handleDelete = () => {
+    deleteRequest({ data: { id: selectedSuggestionId } })
+      .then(() => {
+        ShowSnack('올바르게 삭제되었습니다.', 'success', enqueueSnackbar);
+        history.push('/feature-suggestion');
+      })
+      .catch(() => {
+        ShowSnack('삭제 도중 오류가 발생했습니다. 잠시후 다시 시도해주세요.', 'error', enqueueSnackbar);
+      });
+  };
 
   // 기능제안 상태 Chip 렌더링을 위해
   const progressTab = (value: number) => {
@@ -111,6 +133,26 @@ export default function FeatureDetail({
     }
   };
 
+  if (!currentFeatureData) {
+    return (
+      <Paper
+        component="article"
+        className={classes.secretText}
+      >
+        <Typography>죄송합니다. 삭제된 글이거나 글을 읽어오지 못했습니다.</Typography>
+        <Button
+          className={classes.listButton}
+          style={{ margin: 8 }}
+          size="large"
+          variant="outlined"
+          onClick={onBackClick}
+        >
+          목록
+        </Button>
+      </Paper>
+    );
+  }
+
   return (
     <div>
       <Paper component="article" ref={paperRef}>
@@ -118,10 +160,10 @@ export default function FeatureDetail({
         <div className={classes.title}>
           <div>
             <Typography component="div" variant="h6" className={classes.titleText}>
-              {currentSuggestion.title}
+              {currentFeatureData.title}
               {' '}
-              {progressTab(currentSuggestion.state)}
-              {currentSuggestion.isLock && (
+              {progressTab(currentFeatureData.state)}
+              {currentFeatureData.isLock && (
               <LockIcon
                 color="primary"
                 className={classes.lockIcon}
@@ -130,36 +172,36 @@ export default function FeatureDetail({
               )}
             </Typography>
             <Typography variant="body1" color="textSecondary">
-              {currentSuggestion.author.userId && (
+              {currentFeatureData.author.userId && (
                 <span>
-                  {authContext.user.userId === currentSuggestion.author.userId
-                    ? currentSuggestion.author.userId
-                    : transformIdToAsterisk(currentSuggestion.author.userId, 1.8)}
+                  {authContext.user.userId === currentFeatureData.author.userId
+                    ? currentFeatureData.author.userId
+                    : transformIdToAsterisk(currentFeatureData.author.userId, 1.8)}
                 </span>
               )}
             </Typography>
           </div>
           <Typography color="textSecondary" component="div">
             <Typography>
-              {currentSuggestion.category}
+              {currentFeatureData.category}
             </Typography>
             <Typography>
               {dateExpression({
                 compoName: 'selected-view',
-                createdAt: currentSuggestion?.createdAt,
+                createdAt: currentFeatureData.createdAt,
               })}
             </Typography>
           </Typography>
         </div>
-        {currentSuggestion.author.userId === authContext.user.userId
+        {currentFeatureData.author.userId === authContext.user.userId
         && (
           <div className={classes.editDeleteButtonSet}>
             <Button
               className={classes.editDeleteButton}
               component={Link}
               to={{
-                pathname: `/feature-suggestion/write/${currentSuggestion.suggestionId}`,
-                state: [currentSuggestion],
+                pathname: `/feature-suggestion/write/${currentFeatureData.suggestionId}`,
+                state: [featureDetailData],
               }}
               variant="outlined"
             >
@@ -169,7 +211,7 @@ export default function FeatureDetail({
             <Button
               className={classes.editDeleteButton}
               variant="outlined"
-              onClick={doDelete}
+              onClick={confirmDialog.handleOpen}
             >
               <Delete />
               삭제
@@ -178,55 +220,65 @@ export default function FeatureDetail({
         )}
 
         {/* 내용 섹션 */}
-        <div className={classes.contentsText}>
-          <div className={classes.markdown}>
-            {/* 비밀글 + 자신이 작성한 글이 아닌 경우 비밀글 처리 */}
-            {currentSuggestion.isLock && currentSuggestion.author.userId !== authContext.user.userId ? (
-              <div className={classes.secretText}>
-                <Typography>비밀글의 경우 본인만 확인할 수 있습니다.</Typography>
-                <Button
-                  className={classes.listButton}
-                  size="large"
-                  variant="outlined"
-                  onClick={onBackClick}
-                >
-                  목록
-                </Button>
-              </div>
-            ) : ( // 비밀글이 아닌경우 또는 비밀글 + 자신이 작성한 글인 경우 Viewer 렌더링
-              <Viewer initialValue={currentSuggestion.content} />
-            )}
+        {loading && (
+          <div className={classnames(classes.contentsText, classes.loadingWrapper)}>
+            <CircularProgress />
           </div>
-        </div>
+        )}
+        {!loading && featureDetailData && (
+          <div className={classes.contentsText}>
+            <div className={classes.markdown}>
+              {/* 비밀글 + 자신이 작성한 글이 아닌 경우 비밀글 처리 */}
+              {featureDetailData.isLock && featureDetailData.author.userId !== authContext.user.userId ? (
+                <div className={classes.secretText}>
+                  <Typography>비밀글의 경우 본인만 확인할 수 있습니다.</Typography>
+                  <Button
+                    className={classes.listButton}
+                    size="large"
+                    variant="outlined"
+                    onClick={onBackClick}
+                  >
+                    목록
+                  </Button>
+                </div>
+              ) : ( // 비밀글이 아닌경우 또는 비밀글 + 자신이 작성한 글인 경우 Viewer 렌더링
+                <Viewer initialValue={featureDetailData.content} />
+              )}
+            </div>
+          </div>
+        )}
       </Paper>
 
       {/* 댓글 작성하기 */}
-      {currentSuggestion.author.userId === authContext.user.userId && (
+      {currentFeatureData.author.userId === authContext.user.userId && (
         <FeatureReplyInput
-          currentSuggestion={currentSuggestion}
+          currentSuggestion={currentFeatureData}
           refetch={refetch}
-          avatarLogo={currentSuggestion.author.profileImage || ''}
+          avatarLogo={currentFeatureData.author.profileImage || ''}
         />
       )}
       {/* 댓글 리스트 섹션 */}
-      {currentSuggestion.replies
-      && currentSuggestion.replies.length > 0
-      && (
-        <div style={{ marginTop: 16 }}>
-            {currentSuggestion.replies && currentSuggestion.replies
-              .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-              .map((reply) => (
-                <FeatureReply
-                  avatarLogo={reply.author.profileImage}
-                  key={reply.author.userId + reply.createdAt}
-                  author={reply.author.userId}
-                  content={reply.content}
-                  createdAt={reply.createdAt}
-                  replyId={reply.replyId}
-                  refetch={refetch}
-                />
-              ))}
-        </div>
+      {loading && (
+      <div className={classes.loadingWrapper} style={{ marginTop: 16 }}>
+        <CircularProgress />
+      </div>
+      )}
+      {!loading && featureDetailData && (
+      <div style={{ marginTop: 16 }}>
+        {featureDetailData.replies && featureDetailData.replies
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+          .map((reply) => (
+            <FeatureReply
+              avatarLogo={reply.author.profileImage}
+              key={reply.author.userId + reply.createdAt}
+              author={reply.author.userId}
+              content={reply.content}
+              createdAt={reply.createdAt}
+              replyId={reply.replyId}
+              refetch={refetch}
+            />
+          ))}
+      </div>
       )}
 
       {/* 이전글, 목록, 다음글 버튼셋 */}
@@ -234,7 +286,7 @@ export default function FeatureDetail({
         <Button
           className={classes.pageButton}
           size="large"
-          disabled={currentSuggestionIndex === 0}
+          disabled={currentIndex === 0}
           variant="outlined"
           onClick={() => {
             if (previousFeature.isLock) {
@@ -247,7 +299,7 @@ export default function FeatureDetail({
           }}
         >
           <KeyboardArrowLeft />
-          {currentSuggestionIndex !== 0 && (
+          {currentIndex !== 0 && (
           <Typography>
             {previousFeature.title.length > TITLE_LENGTH
               ? `${previousFeature.title.slice(0, TITLE_LENGTH)}...`
@@ -268,7 +320,7 @@ export default function FeatureDetail({
         <Button
           className={classes.pageButton}
           size="large"
-          disabled={currentSuggestionIndex === data.length - 1}
+          disabled={currentIndex === data.length - 1}
           variant="outlined"
           onClick={() => {
             if (nextFeature.isLock) {
@@ -280,7 +332,7 @@ export default function FeatureDetail({
             }
           }}
         >
-          {currentSuggestionIndex !== data.length - 1 && (
+          {currentIndex !== data.length - 1 && (
           <Typography>
             {nextFeature.title.length > TITLE_LENGTH
               ? `${nextFeature.title.slice(0, TITLE_LENGTH)}...`
@@ -290,6 +342,17 @@ export default function FeatureDetail({
           <KeyboardArrowRight />
         </Button>
       </div>
+
+      <CustomDialog
+        fullWidth
+        maxWidth="sm"
+        open={confirmDialog.open}
+        onClose={confirmDialog.handleClose}
+        buttons
+        callback={handleDelete}
+      >
+        <Typography>해당 기능제안을 삭제하시겠습니까?</Typography>
+      </CustomDialog>
     </div>
   );
 }

--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureDetail.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureDetail.tsx
@@ -65,11 +65,11 @@ export interface FeatureDetailProps {
   selectedSuggestionId: string;
   onBackClick: () => void;
   onOtherFeatureClick: (num: number) => void;
-  refetch: () => void;
+  featureListRefetch: () => void;
 }
 export default function FeatureDetail({
   data, onBackClick, selectedSuggestionId,
-  onOtherFeatureClick, refetch,
+  onOtherFeatureClick, featureListRefetch,
 }: FeatureDetailProps): JSX.Element {
   const classes = useStyles();
   const history = useHistory();
@@ -117,6 +117,7 @@ export default function FeatureDetail({
     deleteRequest({ data: { id: selectedSuggestionId } })
       .then(() => {
         ShowSnack('올바르게 삭제되었습니다.', 'success', enqueueSnackbar);
+        featureListRefetch();
         history.push('/feature-suggestion');
       })
       .catch(() => {
@@ -253,7 +254,7 @@ export default function FeatureDetail({
       {currentFeatureData.author.userId === authContext.user.userId && (
         <FeatureReplyInput
           currentSuggestion={currentFeatureData}
-          refetch={refetch}
+          refetch={featureListRefetch}
           avatarLogo={currentFeatureData.author.profileImage || ''}
         />
       )}
@@ -275,7 +276,7 @@ export default function FeatureDetail({
               content={reply.content}
               createdAt={reply.createdAt}
               replyId={reply.replyId}
-              refetch={refetch}
+              refetch={featureListRefetch}
             />
           ))}
       </div>

--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureTable.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureTable.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
 
 export interface FeatureTableProps {
   isLoading: boolean;
-  metrics: FeatureSuggestion[];
+  metrics: Omit<FeatureSuggestion, 'content' | 'replies'>[];
   page: number;
   pageSize: number;
   handlePage: any;
@@ -70,7 +70,7 @@ export default function FeatureTable({
 
   return (
     <>
-      <Table<FeatureSuggestion>
+      <Table<Omit<FeatureSuggestion, 'content' | 'replies'>>
         columns={[
           {
             width: '50px',

--- a/client/web/src/organisms/mainpage/featureSuggestion/FeatureWriteForm.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/FeatureWriteForm.tsx
@@ -107,7 +107,7 @@ export default function FeatureWriteForm(): JSX.Element {
         .then((res) => {
           if (res.data) {
             ShowSnack('기능제안이 수정 되었습니다.', 'success', enqueueSnackbar);
-            history.push('/feature-suggestion');
+            history.push(`/feature-suggestion/read/${targetSuggestionId}`);
           }
         })
         .catch(() => ShowSnack('기능제안 수정 중 오류가 발생했습니다. 문의 바랍니다.', 'error', enqueueSnackbar));

--- a/client/web/src/organisms/mainpage/featureSuggestion/sub/FeatureReply.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/sub/FeatureReply.tsx
@@ -51,7 +51,8 @@ export default function FeatureReply({
   return (
     <div className={classes.container}>
       <div className={classes.wrapper}>
-        <Avatar src={avatarLogo} variant="square" className={classes.avatar} />
+        {/* 본인이 아닌 경우 프로필사진 기본 사진 처리 */}
+        <Avatar src={auth.user.userId === author ? avatarLogo : ''} variant="square" className={classes.avatar} />
         <div>
           <div className={classes.titleSection}>
             <Typography variant="body2" className={classes.title}>

--- a/client/web/src/organisms/mainpage/featureSuggestion/sub/FeatureReplyInput.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/sub/FeatureReplyInput.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export interface FeatureReplyInputProps {
-  currentSuggestion: FeatureSuggestion;
+  currentSuggestion: Omit<FeatureSuggestion, 'content' | 'replies'>;
   refetch: () => void;
   avatarLogo?: string;
 }

--- a/client/web/src/organisms/shared/sub/HeaderLinks.tsx
+++ b/client/web/src/organisms/shared/sub/HeaderLinks.tsx
@@ -139,6 +139,7 @@ function HeaderLinks(): JSX.Element {
         onClose={handleAnchorClose}
       />
       )}
+      {UserMenuAnchorEl && !profile.loading && profile.data && (
       <UserMenuPopover
         avatarSrc={(!profile.loading && profile.data && profile.data.profileImage)
           ? profile.data.profileImage : ''}
@@ -146,6 +147,7 @@ function HeaderLinks(): JSX.Element {
         anchorEl={UserMenuAnchorEl}
         onClose={handleClose}
       />
+      )}
     </Grid>
   );
 }

--- a/client/web/src/pages/mainpage/FeatureSuggestion.tsx
+++ b/client/web/src/pages/mainpage/FeatureSuggestion.tsx
@@ -111,7 +111,7 @@ export default function FeatureSuggestionPage(): JSX.Element {
                     ? row.category === selectedCategory : row))}
                 onOtherFeatureClick={handleFeatureClick}
                 onBackClick={handleResetFeatureSelect}
-                refetch={featureListRefetch}
+                featureListRefetch={featureListRefetch}
               />
             </div>
           )}

--- a/client/web/src/pages/mainpage/FeatureSuggestion.tsx
+++ b/client/web/src/pages/mainpage/FeatureSuggestion.tsx
@@ -55,7 +55,7 @@ export default function FeatureSuggestionPage(): JSX.Element {
   }
 
   function handleFeatureClick(num: number): void {
-    window.location.replace(`/feature-suggestion/read/${num}`);
+    history.push(`/feature-suggestion/read/${num}`);
   }
   function handleWriteClick(): void {
     history.push('/feature-suggestion/write');
@@ -66,15 +66,17 @@ export default function FeatureSuggestionPage(): JSX.Element {
     setSelectedCategory('전체');
   }
 
+  // ******************************************************************
   // 데이터 요청
-  const [{ loading, data }, featureRefetch] = useAxios<FeatureSuggestion[]>({
-    url: '/feature-suggestion', method: 'GET',
+  const [{ loading, data: featureListData }, featureListRefetch] = useAxios<Omit<FeatureSuggestion, 'content' | 'replies'>[]>({
+    url: '/feature-suggestion/list', method: 'GET',
   });
 
+  // ******************************************************************
   // 기능제아 데이터 요청 (글쓰기 -> 목록으로 돌아와도 새로운 기능제안을 재 요청하지 않는 현상을 수정하기 위해.)
   useEffect(() => {
-    featureRefetch();
-  }, [featureRefetch]);
+    featureListRefetch();
+  }, [featureListRefetch]);
 
   // 페이지네이션
   const [page, setPage] = React.useState(0);
@@ -98,18 +100,18 @@ export default function FeatureSuggestionPage(): JSX.Element {
               <CircularProgress />
             </Paper>
           )}
-          {selectedSuggestionId && !loading && data && (
+          {selectedSuggestionId && !loading && featureListData && (
             <div className={classes.contents}>
               <FeatureDetail
                 selectedSuggestionId={selectedSuggestionId}
-                data={data
+                data={featureListData
                   .sort((row1, row2) => new Date(row2.createdAt).getTime()
                     - new Date(row1.createdAt).getTime())
                   .filter((row) => (selectedCategory !== '전체'
                     ? row.category === selectedCategory : row))}
                 onOtherFeatureClick={handleFeatureClick}
                 onBackClick={handleResetFeatureSelect}
-                refetch={featureRefetch}
+                refetch={featureListRefetch}
               />
             </div>
           )}
@@ -118,9 +120,9 @@ export default function FeatureSuggestionPage(): JSX.Element {
           {!selectedSuggestionId && (
           <div className={classes.contents}>
             <FilterCategoryButtonGroup
-              categories={!loading && data
+              categories={!loading && featureListData
                 ? Array
-                  .from(new Set(data.map((d) => d.category)))
+                  .from(new Set(featureListData.map((d) => d.category)))
                   .sort()
                 : []}
               onChange={handleCategorySelect}
@@ -147,8 +149,8 @@ export default function FeatureSuggestionPage(): JSX.Element {
           <div className={classes.tableContainer}>
             <FeatureTable
               isLoading={loading}
-              metrics={!loading && data
-                ? data
+              metrics={!loading && featureListData
+                ? featureListData
                   .sort((row1, row2) => new Date(row2.createdAt).getTime()
                           - new Date(row1.createdAt).getTime())
                   .filter((row) => (selectedCategory !== '전체'

--- a/server/src/resources/featureSuggestion/featureSuggestion.controller.ts
+++ b/server/src/resources/featureSuggestion/featureSuggestion.controller.ts
@@ -24,11 +24,26 @@ export class FeatureSuggestionController {
   ) { }
 
   /**
-   * 기능제안 리스트 조회 라우터
+   * 기능제안 개별 글 조회 라우터
+   * @param id (optional) 조회할 개별글 번호. 파라미터 추가하지 않을 시 모든 글 목록을 반환합니다.
    */
   @Get()
-  async findAll(): Promise<FeatureSuggestionEntity[]> {
+  async findOne(
+    @Query('id') id: string,
+  ): Promise<FeatureSuggestionEntity | FeatureSuggestionEntity[]> {
+    if (id) {
+      return this.featureSuggestionService.findOne(id);
+    }
     return this.featureSuggestionService.findAll();
+  }
+
+  /**
+   * 기능제안 목록 조회 라우터 ( 글의 내용 / 댓글 내용은 포함하지 않는 순수 목록만 반환)
+   */
+  @Get('list')
+  async findAllList(): Promise<FeatureSuggestionEntity[]> {
+    console.error('hi from feature-suggestion / list');
+    return this.featureSuggestionService.findAllList();
   }
 
   /**

--- a/server/src/resources/featureSuggestion/featureSuggestion.service.ts
+++ b/server/src/resources/featureSuggestion/featureSuggestion.service.ts
@@ -17,12 +17,34 @@ export class FeatureSuggestionService {
   ) {}
 
   /**
+   * 기능제안 개별 글 조회 메소드
+   * @param id 조회할 기능 제안 글번호
+   */
+  public async findOne(id: string): Promise<FeatureSuggestionEntity> {
+    return this.FeatureSuggestionRepository.findOne(id, {
+      relations: ['author', 'replies', 'replies.author'],
+    });
+  }
+
+  /**
    * 기능 제안 리스트 조회 메소드
    */
   public async findAll(): Promise<FeatureSuggestionEntity[]> {
     return this.FeatureSuggestionRepository.find({
       order: { createdAt: 'DESC' },
       relations: ['author', 'replies', 'replies.author'],
+    });
+  }
+
+  /**
+   * 기능제안 순수 목록 조회 메소드.
+   * 내용은 포함하지 않습니다.
+   */
+  public async findAllList(): Promise<FeatureSuggestionEntity[]> {
+    return this.FeatureSuggestionRepository.find({
+      order: { createdAt: 'DESC' },
+      select: ['author', 'category', 'createdAt', 'isLock', 'title', 'suggestionId', 'state'],
+      relations: ['author', 'replies'],
     });
   }
 


### PR DESCRIPTION
# 문제점

1. 기능제안 history.replace 를 react-router로 수정 및 개별글 변경되지 않는 현상 수정
2. 모든 글에 대한 데이터를 한번에 불러오니 목록에서 렉걸리는 현상 발생

## 해결방안

- 프론트
    - 기능제안 목록에서는 단순 목록만(제목,날짜,비밀여부 등 컨텐츠를 제외한)
    - 기능제안 개별글보기 클릭 시 해당 기능제안 데이터를 요청
- 백
    - 개별글 GET controller
    - 목록 GET controller