### PR TITLE
[TP-SPRINT #3.2] 채널 연동시 CollectorDB 데이터 수집 타겟 목록에 추가 & 로그인시 연동된 아/트/유 정보 업데이트

### DIFF
--- a/client/web/src/organisms/mypage/my-office/ManagePlatformLink.tsx
+++ b/client/web/src/organisms/mypage/my-office/ManagePlatformLink.tsx
@@ -41,6 +41,10 @@ export default function ManagePlatformLink({
   const { enqueueSnackbar } = useSnackbar();
 
   // *******************************
+  // 연동 해제 확인 다이얼로그
+  const confirmDialog = useDialog();
+
+  // *******************************
   // 연동 "제거" 요청
   const [, linkDeleteRequest] = useAxios({
     method: 'DELETE', url: '/auth/link',
@@ -53,7 +57,10 @@ export default function ManagePlatformLink({
         userDataRefetch();
         ShowSnack(`${capitalize(platform)} 연동 해제 되었습니다.`, 'success', enqueueSnackbar);
       })
-      .catch(() => ShowSnack(`${capitalize(platform)} 연동 해제중 오류가 발생했습니다. 문의바랍니다.`, 'error', enqueueSnackbar));
+      .catch(() => {
+        confirmDialog.handleClose();
+        ShowSnack(`${capitalize(platform)} 연동 해제중 오류가 발생했습니다. 문의바랍니다.`, 'error', enqueueSnackbar);
+      });
   }
 
   // *******************************
@@ -63,10 +70,6 @@ export default function ManagePlatformLink({
     if (platform === 'afreeca') params += `?__userId=${auth.user.userId}`;
     window.location.href = `${getApiHost()}/auth/${params}`;
   }
-
-  // *******************************
-  // 연동 해제 확인 다이얼로그
-  const confirmDialog = useDialog();
 
   // 선택된 플랫폼 정보 스테이트
   const [selectedPlatform, setSelectedPlatform] = useState<Platform | undefined>();

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { HighlightModule } from './resources/highlightPoint/hightlight.module';
 import { FeatureModule } from './resources/featureSuggestion/featureSuggestion.module';
 import { InquiryModule } from './resources/inquiry/inquiry.module';
 import { TypeOrmConfigService } from './config/database.config';
+import { CollectorTypeOrmConfigService } from './config/collector.database.config';
 import { NotificationModule } from './resources/notification/notification.module';
 import { StreamAnalysisModule } from './resources/stream-analysis/stream-analysis.module';
 
@@ -24,6 +25,10 @@ import { HealthCheckModule } from './resources/health-check/healthcheck.module';
     ConfigModule.forRoot({ isGlobal: true, load: [loadConfig] }),
     TypeOrmModule.forRootAsync({
       useClass: TypeOrmConfigService,
+    }),
+    TypeOrmModule.forRootAsync({
+      name: 'WhileTrueCollectorDB',
+      useClass: CollectorTypeOrmConfigService,
     }),
     AccessControlModule.forRoles(roles),
     AuthModule,

--- a/server/src/collector-entities/afreeca/activeStreams.entity.ts
+++ b/server/src/collector-entities/afreeca/activeStreams.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column, Entity, PrimaryGeneratedColumn,
+} from 'typeorm';
+
+// 방송 진행 여부에 따라 지속 업데이트 되는 테이블이며 가장 최신의 방송정보들을 가지고 있다.(트루포인트에서 아프리카를 구독한 회원만큼의 row 존재, 지속 업데이트 됨)
+// - videoId(PK) : 아프리카 방송을 Luke의 자체적인 고윳값을 지정한 값
+// - creatorId : 크리에이터ID
+// - creatorName : 크리에이터 활동명
+// - is_live : 방송 시작 및 종료 여부
+// - startDate : 방송 시작시간
+// - endDate : 방송 종료시간
+@Entity('AfreecaActiveStreams')
+export class AfreecaActiveStreamsEntity {
+  @PrimaryGeneratedColumn()
+  id: string;
+
+  @Column()
+  creatorId: string;
+
+  @Column()
+  creatorName: string;
+
+  @Column({ default: false })
+  is_live?: boolean;
+
+  @Column({ default: false })
+  is_private?: boolean;
+
+  @Column({ type: 'timestamp' })
+  startDate: Date;
+
+  @Column({ type: 'timestamp' })
+  endDate: Date;
+}

--- a/server/src/collector-entities/afreeca/targetStreamers.entity.ts
+++ b/server/src/collector-entities/afreeca/targetStreamers.entity.ts
@@ -1,0 +1,21 @@
+import {
+  Column, CreateDateColumn, Entity, UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('AfreecaTargetStreamers')
+export class AfreecaTargetStreamersEntity {
+  @Column({ primary: true })
+  creatorId: string;
+
+  @Column()
+  creatorName: string;
+
+  @Column({ length: 150 })
+  refreshToken: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt: Date;
+}

--- a/server/src/collector-entities/twitch/targetStreamers.entity.ts
+++ b/server/src/collector-entities/twitch/targetStreamers.entity.ts
@@ -1,0 +1,22 @@
+import {
+  Column, CreateDateColumn, Entity, UpdateDateColumn,
+} from 'typeorm';
+
+// collectors/twitchtv/src/model/member.py 참고하세요.
+@Entity('TwitchTargetStreamers')
+export class TwitchTargetStreamersEntity {
+  @Column({ primary: true })
+  streamerId: string;
+
+  @Column()
+  streamerName: string;
+
+  @Column({ length: 100 })
+  streamChannelName: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/server/src/collector-entities/youtube/targetStreamers.entity.ts
+++ b/server/src/collector-entities/youtube/targetStreamers.entity.ts
@@ -1,0 +1,15 @@
+import {
+  Column, Entity,
+} from 'typeorm';
+
+@Entity('YoutubeTargetStreamers')
+export class YoutubeTargetStreamersEntity {
+  @Column({ primary: true })
+  channelId: string;
+
+  @Column({ nullable: true })
+  channelName: string;
+
+  @Column({ length: 150, nullable: true })
+  refresh_token: string;
+}

--- a/server/src/config/collector.database.config.ts
+++ b/server/src/config/collector.database.config.ts
@@ -4,13 +4,14 @@ import { TypeOrmOptionsFactory, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DbSecret } from '../interfaces/Secrets.interface';
 
 @Injectable()
-export class TypeOrmConfigService implements TypeOrmOptionsFactory {
+export class CollectorTypeOrmConfigService implements TypeOrmOptionsFactory {
   constructor(private readonly configService: ConfigService) { }
 
   createTypeOrmOptions(): TypeOrmModuleOptions {
-    const database = this.configService.get<DbSecret>('database');
+    const database = this.configService.get<DbSecret>('WhileTrueCollectorDB');
 
     return {
+      name: 'WhileTrueCollectorDB',
       type: database.engine,
       host: database.host,
       port: database.port,
@@ -18,8 +19,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       password: database.password,
       database: database.dbname,
       timezone: 'Asia/Seoul',
-      synchronize: true,
-      entities: [`${__dirname}/../resources/**/*.entity{.ts,.js}`],
+      entities: [`${__dirname}/../collector-entities/**/*.entity{.ts,.js}`],
     };
   }
 }

--- a/server/src/config/loadConfig.ts
+++ b/server/src/config/loadConfig.ts
@@ -5,7 +5,7 @@
 
 // Load the AWS SDK
 import AWS from 'aws-sdk';
-import { TruepointSecret, TruepointDbSecret } from '../interfaces/Secrets.interface';
+import { TruepointDbSecret, DbSecret, CollectorDbSecret } from '../interfaces/Secrets.interface';
 
 const region = 'ap-northeast-2';
 AWS.config.update({
@@ -20,17 +20,15 @@ const client = new AWS.SecretsManager({ region });
 // See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
 // We rethrow the exception by default.
 
-async function getDbSecrets(): Promise<TruepointDbSecret> {
-  let secret: TruepointDbSecret;
+/**
+ * Truepoint 앱 DB Secret 정보를 가져오는 함수.
+ */
+async function getDbSecrets(secretsName: string): Promise<DbSecret> {
+  let secret: DbSecret;
   try {
     const list = await client.listSecrets().promise();
     const target = list.SecretList.find(
-      (x) => x.Name.includes(
-        process.env.NODE_ENV === 'production'
-          // ? 'TruepointProductionDB' // production 환경( 정확히는, production RDS DB) 이 준비되었을 때.
-          ? 'TruepointDevDB'
-          : 'TruepointDevDB',
-      ),
+      (x) => x.Name.includes(secretsName),
     );
 
     const dbSecretData = await client
@@ -71,10 +69,21 @@ async function getDbSecrets(): Promise<TruepointDbSecret> {
 }
 
 // config service
-export default async (): Promise<TruepointSecret> => {
-  const dbSecrets = await getDbSecrets();
+export default async (): Promise<TruepointDbSecret | CollectorDbSecret> => {
+  const truepointDbName = process.env.NODE_ENV === 'production'
+  // ? 'TruepointProductionDB' // production 환경( 정확히는, production RDS DB) 이 준비되었을 때.
+    ? 'TruepointDevDB'
+    : 'TruepointDevDB';
+
+  // Truepoint App DB Secrets
+  const dbSecrets = await getDbSecrets(truepointDbName);
+
+  // Collector DB Secrets
+  const collectorDbName = 'WhileTrueCollectorDB';
+  const collectorDbSecerts = await getDbSecrets(collectorDbName);
 
   return {
     database: { ...dbSecrets },
+    WhileTrueCollectorDB: { ...collectorDbSecerts },
   };
 };

--- a/server/src/interfaces/Secrets.interface.ts
+++ b/server/src/interfaces/Secrets.interface.ts
@@ -1,4 +1,4 @@
-export interface TruepointDbSecret {
+export interface DbSecret {
   password: string;
   engine: 'mysql' | 'mariadb';
   port: number;
@@ -7,6 +7,10 @@ export interface TruepointDbSecret {
   dbname: string;
 }
 
-export interface TruepointSecret {
-  database: TruepointDbSecret;
+export interface TruepointDbSecret {
+  database: DbSecret;
+}
+
+export interface CollectorDbSecret {
+  WhileTrueCollectorDB: DbSecret;
 }

--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -146,14 +146,14 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   async deletePlatformLink(
     @Req() req: LogedInExpressRequest, @Body('platform') platform: string,
-  ): Promise<number> {
+  ): Promise<string> {
     const { userId } = req.user;
-    const result = await this.usersService.disconnectLink(userId, platform);
+    const deletedPlatformId = await this.usersService.disconnectLink(userId, platform);
 
     // 링크 정보 (PlatformTwitch, PlatformYoutube PlatformAfreeca) 삭제
-    await this.usersService.deleteLinkUserPlatform(userId, platform);
+    await this.usersService.deleteLinkUserPlatform(deletedPlatformId, platform);
 
-    return result;
+    return deletedPlatformId;
   }
 
   // *********** Twitch ******************

--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -142,7 +142,7 @@ export class AuthController {
     const result = await this.usersService.disconnectLink(userId, platform);
 
     // 링크 정보 (PlatformTwitch, PlatformYoutube PlatformAfreeca) 삭제
-    // const result2 = await this.usersService.deleteLinkUserPlatform(userId, platform);
+    await this.usersService.deleteLinkUserPlatform(userId, platform);
 
     return result;
   }

--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -244,11 +244,14 @@ export class AuthController {
     } = await this.afreecaLinker.getTokens(afreecaAuthorizationCode as string);
 
     // link with truepoint user
+    // by hwasurr, 2020.12.08 아직 아프리카 open API에서는 유저 프로필을 제공하지 않아 실제 유저 아이디를 조회할 수 없음 -> 향후 업데이트 필요.
+    // 현재는 트루포인트 userID를 넣는다.
     await this.afreecaLinker.link(refreshToken, userId)
       .then(() => {
         // settings뒤에 / 꼭 추가. amplify redirect 관련한 일종의 버그 있음.
         // https://github.com/aws-amplify/amplify-console/issues/97
 
+        // by hwasurr, 2020.12.08 아직 아프리카 open API에서는 유저 프로필을 제공하지 않아 실제 유저 아이디를 조회할 수 없음 -> 향후 업데이트 필요.
         // 실제 아프리카 유저 아이디를 들고올 수 있을 때, id, platform 쿼리스트링 추가
         res.redirect(`${getFrontHost()}/mypage/my-office/settings/`); // ?id=${afreecaId}&platform=afreeca
       })

--- a/server/src/resources/auth/auth.module.ts
+++ b/server/src/resources/auth/auth.module.ts
@@ -9,7 +9,7 @@ import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { TwitchStrategy } from './strategies/twitch.strategy';
 import { YoutubeStrategy } from './strategies/youtube.strategy';
-import { AfreecaPreLinker } from './strategies/afreeca.linker';
+import { AfreecaLinker } from './strategies/afreeca.linker';
 
 @Module({
   imports: [
@@ -21,9 +21,9 @@ import { AfreecaPreLinker } from './strategies/afreeca.linker';
   ],
   providers: [
     AuthService, LocalStrategy,
-    JwtStrategy, TwitchStrategy, YoutubeStrategy, AfreecaPreLinker,
+    JwtStrategy, TwitchStrategy, YoutubeStrategy, AfreecaLinker,
   ],
   controllers: [AuthController],
-  exports: [AuthService],
+  exports: [AuthService, AfreecaLinker],
 })
 export class AuthModule {}

--- a/server/src/resources/auth/auth.service.ts
+++ b/server/src/resources/auth/auth.service.ts
@@ -71,7 +71,7 @@ export class AuthService {
     // 로그인 상태 유지에 따라 다른 유지기간의 refresh token 발급
     const refreshToken = this.createRefreshToken(user.userId, stayLogedIn);
     // refresh token 적재
-    this.usersService.saveRefreshToken({
+    await this.usersService.saveRefreshToken({
       userId: user.userId, refreshToken,
     });
     return { accessToken, refreshToken };

--- a/server/src/resources/auth/strategies/afreeca.linker.ts
+++ b/server/src/resources/auth/strategies/afreeca.linker.ts
@@ -1,10 +1,12 @@
 import Axios from 'axios';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  forwardRef, Inject, Injectable, InternalServerErrorException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UsersService } from '../../users/users.service';
 
 @Injectable()
-export class AfreecaPreLinker {
+export class AfreecaLinker {
   private readonly AFREECA_AUTH_URL = 'https://openapi.afreecatv.com/auth/code';
 
   private readonly AFREECA_TOKEN_URL = 'https://openapi.afreecatv.com/auth/token';
@@ -15,6 +17,7 @@ export class AfreecaPreLinker {
 
   constructor(
     private readonly configService: ConfigService,
+    @Inject(forwardRef(() => UsersService))
     private readonly usersService: UsersService,
   ) {
     this.AFREECA_KEY = configService.get<string>('AFREECA_KEY');
@@ -61,6 +64,28 @@ export class AfreecaPreLinker {
     } catch (e) {
       console.error('An Error occurred during getting refreshtoken from afreecatv', e.message);
       throw new InternalServerErrorException('An Error occurred during getting refreshtoken from afreecatv');
+    }
+  }
+
+  /**
+   * 리프레시토큰을 통해 새로 갱신한 액세스 토큰을 받아와 반환하는 메소드
+   * @param refreshToken 리프레시 토큰
+   */
+  async refresh(refreshToken: string): Promise<{
+    accessToken: string; refreshToken: string;
+  }> {
+    try {
+      const response = await Axios.post(this.AFREECA_TOKEN_URL, {
+        grant_type: 'refresh_token',
+        client_id: this.AFREECA_KEY,
+        client_secret: this.AFREECA_SECRET_KEY,
+        refresh_token: refreshToken,
+      });
+      const { access_token: newAccessToken, refresh_token: newRefreshToken } = response.data;
+      return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+    } catch (e) {
+      console.error('An Error occurred during refreshing afreecatv access token', e.message);
+      throw new InternalServerErrorException('An Error occurred during refreshing afreecatv access token');
     }
   }
 

--- a/server/src/resources/auth/strategies/afreeca.linker.ts
+++ b/server/src/resources/auth/strategies/afreeca.linker.ts
@@ -92,7 +92,7 @@ export class AfreecaLinker {
   /**
    * 트루포인트 유저 ID, 리프레시 토큰을 받아 TP-Afreeca연동 정보를 남기는 메소드
    * 현재 (2020.11.12) 아프리카 연동 유저의 Profile을 받지 못하므로, 연동 AfreecaId를 TP-userId로 둔다.
-   * userProfile을 받을 수 있는 상황이 되면 해당 유저의 ID를 연동 Afreeca 아이디로 두도록 변경하여야 한다.
+   * userProfile을 받을 수 있는 상황이 되면 해당 유저의 ID를 연동 Afreeca 아이디로 두도록 변경하여야 한다. by hwasurr
    * @param refreshToken 해당 유저의 리프레시 토큰
    * @param userId 해당 유저 Truepoint ID
    */

--- a/server/src/resources/auth/strategies/youtube.strategy.ts
+++ b/server/src/resources/auth/strategies/youtube.strategy.ts
@@ -20,7 +20,7 @@ export class YoutubeStrategy extends PassportStrategy(Strategy, 'google') {
       scope: [
         'email', 'profile',
         'https://www.googleapis.com/auth/youtube', // 유튜브 계정 관리 및 보기
-        // 'https://www.googleapis.com/auth/yt-analytics.readonly',
+        // 'https://www.googleapis.com/auth/yt-analytics.readonly', // 유튜브 통계 및 분석 보기
       ],
       callbackURL: `${getApiHost()}/auth/youtube/callback`,
     });

--- a/server/src/resources/users/users.module.ts
+++ b/server/src/resources/users/users.module.ts
@@ -13,6 +13,7 @@ import { SubscribeEntity } from './entities/subscribe.entity';
 import { AfreecaTargetStreamersEntity } from '../../collector-entities/afreeca/targetStreamers.entity';
 import { YoutubeTargetStreamersEntity } from '../../collector-entities/youtube/targetStreamers.entity';
 import { TwitchTargetStreamersEntity } from '../../collector-entities/twitch/targetStreamers.entity';
+import { AfreecaActiveStreamsEntity } from '../../collector-entities/afreeca/activeStreams.entity';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { TwitchTargetStreamersEntity } from '../../collector-entities/twitch/tar
     ]),
     TypeOrmModule.forFeature([
       AfreecaTargetStreamersEntity,
+      AfreecaActiveStreamsEntity,
       YoutubeTargetStreamersEntity,
       TwitchTargetStreamersEntity,
     ], 'WhileTrueCollectorDB'), // collectorDB Entity 연결

--- a/server/src/resources/users/users.module.ts
+++ b/server/src/resources/users/users.module.ts
@@ -10,17 +10,26 @@ import { PlatformTwitchEntity } from './entities/platformTwitch.entity';
 import { PlatformYoutubeEntity } from './entities/platformYoutube.entity';
 import { UserTokenEntity } from './entities/userToken.entity';
 import { SubscribeEntity } from './entities/subscribe.entity';
+import { AfreecaTargetStreamersEntity } from '../../collector-entities/afreeca/targetStreamers.entity';
+import { YoutubeTargetStreamersEntity } from '../../collector-entities/youtube/targetStreamers.entity';
+import { TwitchTargetStreamersEntity } from '../../collector-entities/twitch/targetStreamers.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([
-    PlatformAfreecaEntity,
-    PlatformTwitchEntity,
-    PlatformYoutubeEntity,
-    UserEntity,
-    UserTokenEntity,
-    SubscribeEntity,
-  ]),
-  forwardRef(() => AuthModule), // Resolve circular dependencies between Modules
+  imports: [
+    TypeOrmModule.forFeature([
+      PlatformAfreecaEntity,
+      PlatformTwitchEntity,
+      PlatformYoutubeEntity,
+      UserEntity,
+      UserTokenEntity,
+      SubscribeEntity,
+    ]),
+    TypeOrmModule.forFeature([
+      AfreecaTargetStreamersEntity,
+      YoutubeTargetStreamersEntity,
+      TwitchTargetStreamersEntity,
+    ], 'WhileTrueCollectorDB'), // collectorDB Entity 연결
+    forwardRef(() => AuthModule), // Resolve circular dependencies between Modules
   ],
   providers: [
     UsersService,

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -421,11 +421,12 @@ export class UsersService {
           targetUser[`${platform}Id`] = platformId;
           // ************************************************
           // CollectorDB target Streamer에 추가
-          this.afreecaTargetStreamersRepository.save({
-            creatorId: linkedInfo.afreecaId,
-            creatorName: linkedInfo.afreecaStreamerName,
-            refreshToken: linkedInfo.refreshToken,
-          });
+          // by hwasurr 2020. 12. 08 아직 Afreeca openAPI 에서는 ProfileData를 제공하지 않기 때문에 주석처리. 향후 업데이트 필요
+          // this.afreecaTargetStreamersRepository.save({
+          //   creatorId: linkedInfo.afreecaId,
+          //   creatorName: linkedInfo.afreecaStreamerName,
+          //   refreshToken: linkedInfo.refreshToken,
+          // });
           break;
         } else {
           throw new InternalServerErrorException(


### PR DESCRIPTION
## 채널 연동시 CollectorDB 데이터 수집 타겟 목록에 추가

### 문제사항 (내용)

트루포인트 유저가 채널 연동 시, 데이터 수집이 진행될 수 있게 CollectorDB의 타겟 유저 목록에 추가해야 한다.

아프리카 / 트위치 / 유튜브 모두.

### 해결방안

- **백엔드 DB를 두개 연결하도록 변경한다. (multiple connection)**
- **채널 연동 시, 수집 타겟 유저 목록에 삽입 | 채널 연동 취소 시, 수집 타겟 유저 목록에서 제거**

### 체크리스트

- [x]  두 개 (CollectorDB, TruepointDB) 의 DB 연결
    - [x]  두 DB Secert 조회
    - [x]  두 DB Connection 인스턴스 생성
        - **CollectorDB의 경우 sync X**
    - [x]  두 DB Connection을 필요한 곳에서 올바르게 사용할 수 있도록 처리 ( unique name에 따라 )
        - [x]  AppModule - forRoot 추가
        - [x]  UsersModule - forFeature 추가
- [x]  Collector DB Entity 생성
    - [x]  twitch
    - [x]  afreeca
    - [x]  youtube
- [x]  연동 시, 수집 타겟 목록에 추가
    - [x]  아프리카
    - [x]  트위치
    - [x]  유튜브
- [x]  연동 제거 시, 수집 타겟 목록에서 제거
    - [x]  아프리카
    - [x]  트위치
    - [x]  유튜브

---
## 로그인시 연동된 아/트/유 정보 업데이트
### 문제사항 (내용)

최신 user 정보를 받아와 truepoint DB의 유저플랫폼 연동 정보를 최신화 해야한다.

- why ?
    1. 유저 닉네임 불일치
    2. 유저 로고 불일치
    3. ...

### 해결방안

- **프론트**

    ~~로그인 시, 연동정보 최신화 요청을 보낸다~~ 
    **로그인 요청 시, 백엔드에서 연동 정보를 확인하고 곧바로 실행 되므로 따로 처리할 필요 없다.**

- **백엔드**

    각 플랫폼 별로 연동 정보 최신화 요청을 받으면, refresh_token으로 새로운 accesstoken을 받아온다.

    새로운 access Token으로 플랫폼에 유저 정보를 요청하고 최신화 한다.

### 체크리스트

- 각 플랫폼 연동 정보 유저프로필 최신화 구현
    - 트위치
        - [x]  트위치 accessToken 리프레시
        - [x]  유튜브 유저 프로필 요청
        - [x]  새로운 유저 프로필로 유저 정보 최신화
    - 아프리카
        - [x]  베이스 코드 작성(아직 UserProfile을 제공하지 않으므로 이후 업데이트사항으로 둔다.)
        - [x]  향후업데이트필요 주석 작성(아직 UserProfile을 제공하지 않으므로 이후 업데이트사항으로 둔다.)
    - 유튜브
        - [x]  유튜브 accessToken 리프레시
        - [x]  유튜브 유저 프로필 요청
        - [x]  새로운 유저 프로필로 유저 정보 최신화
- 로그인 시 자동 처리 구현
    - [x]  로그인한 유저의 연동 정보 조회 → 연동된 플랫폼의 정보만 최신화작업 실행 코드 작성
    - [x]  동일하게 아프리카 TV는 아직 UserProfile 제공하지 않으므로 이후 업데이트사항으로 둔다.)