### PR TITLE
[TP-SPRINT #3.2] 리스트 툴팁 "평균" 텍스트 추가

### DIFF
--- a/client/web/src/organisms/mypage/stream-analysis/shared/PeriodStreamsList.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/shared/PeriodStreamsList.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexDirection: 'column',
   },
   chip: {
-    marginRight: theme.spacing(2),
+    marginRight: theme.spacing(4),
   },
   tooltip: {
     height: 'auto',
@@ -163,8 +163,8 @@ export default function PeriodStreamsList(props: PeriodStreamsListProps): JSX.El
 
       <div className={classes.tooltipChipWrapper}>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 8 }}>
-            시청자수
+          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+            평균 시청자수
           </Typography>
           <Chip
             icon={<PersonAddIcon />}
@@ -175,8 +175,8 @@ export default function PeriodStreamsList(props: PeriodStreamsListProps): JSX.El
           />
         </div>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 12 }}>
-            채팅수
+          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+            평균 채팅수
           </Typography>
           <Chip
             icon={<ChatIcon />}
@@ -188,7 +188,7 @@ export default function PeriodStreamsList(props: PeriodStreamsListProps): JSX.El
         </div>
         <div className={classes.chipWapper}>
           <Typography variant="caption" style={{ marginBottom: 4 }}>
-            웃음 발생 수
+            평균 웃음 발생 수
           </Typography>
           <Chip
             icon={<EmojiEmotionsIcon />}

--- a/client/web/src/organisms/mypage/stream-analysis/shared/PeriodStreamsList.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/shared/PeriodStreamsList.tsx
@@ -97,6 +97,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   chip: {
     marginRight: theme.spacing(4),
   },
+  chipLable: {
+    marginBottom: 4, marginLeft: 4,
+  },
   tooltip: {
     height: 'auto',
     padding: theme.spacing(1),
@@ -163,7 +166,7 @@ export default function PeriodStreamsList(props: PeriodStreamsListProps): JSX.El
 
       <div className={classes.tooltipChipWrapper}>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+          <Typography variant="caption" className={classes.chipLable}>
             평균 시청자수
           </Typography>
           <Chip
@@ -175,7 +178,7 @@ export default function PeriodStreamsList(props: PeriodStreamsListProps): JSX.El
           />
         </div>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+          <Typography variant="caption" className={classes.chipLable}>
             평균 채팅수
           </Typography>
           <Chip
@@ -187,7 +190,7 @@ export default function PeriodStreamsList(props: PeriodStreamsListProps): JSX.El
           />
         </div>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4 }}>
+          <Typography variant="caption" className={classes.chipLable}>
             평균 웃음 발생 수
           </Typography>
           <Chip

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamList.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamList.tsx
@@ -55,7 +55,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexDirection: 'column',
   },
   chip: {
-    marginRight: theme.spacing(2),
+    marginRight: theme.spacing(4),
   },
   tooltip: {
     height: 'auto',
@@ -104,8 +104,8 @@ export default function StreamList(props: StreamListProps): JSX.Element {
 
       <div className={classes.tooltipChipWrapper}>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 8 }}>
-            시청자수
+          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+            평균 시청자수
           </Typography>
           <Chip
             icon={<PersonAddIcon />}
@@ -116,8 +116,8 @@ export default function StreamList(props: StreamListProps): JSX.Element {
           />
         </div>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 12 }}>
-            채팅수
+          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+            평균 채팅수
           </Typography>
           <Chip
             icon={<ChatIcon />}
@@ -129,7 +129,7 @@ export default function StreamList(props: StreamListProps): JSX.Element {
         </div>
         <div className={classes.chipWapper}>
           <Typography variant="caption" style={{ marginBottom: 4 }}>
-            웃음 발생 수
+            평균 웃음 발생 수
           </Typography>
           <Chip
             icon={<EmojiEmotionsIcon />}

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamList.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamList.tsx
@@ -57,6 +57,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   chip: {
     marginRight: theme.spacing(4),
   },
+  chipLable: {
+    marginBottom: 4, marginLeft: 4,
+  },
   tooltip: {
     height: 'auto',
     padding: theme.spacing(1),
@@ -104,7 +107,7 @@ export default function StreamList(props: StreamListProps): JSX.Element {
 
       <div className={classes.tooltipChipWrapper}>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+          <Typography variant="caption" className={classes.chipLable}>
             평균 시청자수
           </Typography>
           <Chip
@@ -116,7 +119,7 @@ export default function StreamList(props: StreamListProps): JSX.Element {
           />
         </div>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4, marginLeft: 4 }}>
+          <Typography variant="caption" className={classes.chipLable}>
             평균 채팅수
           </Typography>
           <Chip
@@ -128,7 +131,7 @@ export default function StreamList(props: StreamListProps): JSX.Element {
           />
         </div>
         <div className={classes.chipWapper}>
-          <Typography variant="caption" style={{ marginBottom: 4 }}>
+          <Typography variant="caption" className={classes.chipLable}>
             평균 웃음 발생 수
           </Typography>
           <Chip


### PR DESCRIPTION
### 리스트 툴팁 '평균' 텍스트 추가
1. 방송분석 - shared (기간 대 기간 , 기간 추이 적용)
2. 방송분석 - 방송 대 방송 적용

### 미비사항
편집점 분석 탭 리스트에는 적용 되지 않음
( harry-stream-list-shared-router 브랜치 적용사항 이후에 적용가능 )