### PR TITLE
[TP-SPRINT #3 버그수정] 채널연동 수정점

### DIFF
--- a/.github/workflows/production-api-server.yml
+++ b/.github/workflows/production-api-server.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build, tag, and push image to Docker Hub
         uses: elgohr/Publish-Docker-Github-Action@2.14
+        env:
+          NODE_ENV: production
         with:
           dockerfile: server/Dockerfile
           name: ${{ secrets.DOCKER_USERNAME }}/truepoint-api

--- a/.github/workflows/test-api-server.yml
+++ b/.github/workflows/test-api-server.yml
@@ -39,8 +39,10 @@ jobs:
 
       - name: Build, tag, and push image to Docker Hub
         uses: elgohr/Publish-Docker-Github-Action@2.14
+        env:
+          NODE_ENV: test
         with:
-          dockerfile: server/Dockerfile
+          dockerfile: server/test.Dockerfile
           name: ${{ secrets.DOCKER_USERNAME }}/test-truepoint-api
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/client/web/src/organisms/mypage/my-office/ManagePlatformLink.tsx
+++ b/client/web/src/organisms/mypage/my-office/ManagePlatformLink.tsx
@@ -106,7 +106,9 @@ export default function ManagePlatformLink({
         </div>
       </div>
 
-      <div className={classes.container}>
+      {/* 아프리카TV 연동 기능 임시 제거 (CBT 포함X - @Dan, @Robert, 2020.12.16) */}
+      {/* WARNING!!!!!!! 제거하면 안됩니다 */}
+      {/* <div className={classes.container}>
         <div className={classes.label}>
           <Avatar src="/images/logo/afreecaLogo.png" className={classes.avatar} />
           <Typography>아프리카 TV</Typography>
@@ -131,7 +133,7 @@ export default function ManagePlatformLink({
             </Button>
           )}
         </div>
-      </div>
+      </div> */}
 
       <div className={classes.container}>
         <div className={classes.label}>

--- a/client/web/src/pages/mypage/my-office/Settings.tsx
+++ b/client/web/src/pages/mypage/my-office/Settings.tsx
@@ -104,6 +104,9 @@ export default function Settings(): JSX.Element {
             <Typography variant="body2" color="textSecondary">
               플랫폼 연동을 통해 트루포인트를 바로 시작해보세요.
             </Typography>
+            <Typography variant="caption" color="textSecondary">
+              아프리카TV의 경우 아직 연동 기능을 제공하지 않습니다. 아프리카TV 방송 데이터를 연동하고싶으신 분은 우측 아래 버튼으로 카카오톡 문의부탁드립니다.
+            </Typography>
           </div>
           {!!alreadyLinkedWithOther && (
             <PlatformLinkErrorAlert

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "cross-env NODE_ENV=development nest start",
+    "start": "cross-env nest start",
     "start:dev": "cross-env NODE_ENV=development nest start  --watch",
     "start:debug": "cross-env NODE_ENV=development nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -39,6 +39,7 @@ async function bootstrap() {
     credentials: true,
   });
 
+  console.log(`server listen on ${process.env.NODE_ENV || 'development'} mode: `);
   await app.listen(3000);
 }
 bootstrap();

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -39,7 +39,8 @@ async function bootstrap() {
     credentials: true,
   });
 
-  console.log(`server listen on ${process.env.NODE_ENV || 'development'} mode: `);
+  // eslint-disable-next-line no-console
+  console.log(`Running Evironment: ${process.env.NODE_ENV || 'development'}`);
   await app.listen(3000);
 }
 bootstrap();

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -506,8 +506,10 @@ export class UsersService {
 
       // 선택된 로고 + 닉네임 제거
       const afreeca = await this.afreecaRepository.findOne(targetUser.afreecaId);
-      targetPlatformLogo = afreeca.logo;
-      targetPlatformNickname = afreeca.afreecaStreamerName;
+      if (afreeca) {
+        targetPlatformLogo = afreeca.logo;
+        targetPlatformNickname = afreeca.afreecaStreamerName;
+      }
     }
     if (platform === 'twitch') {
       deletedPlatformId = targetUser.twitchId;
@@ -518,8 +520,10 @@ export class UsersService {
 
       // 선택된 로고 + 닉네임 제거
       const twitch = await this.twitchRepository.findOne(targetUser.twitchId);
-      targetPlatformLogo = twitch.logo;
-      targetPlatformNickname = twitch.twitchChannelName;
+      if (twitch) {
+        targetPlatformLogo = twitch.logo;
+        targetPlatformNickname = twitch.twitchChannelName;
+      }
     }
     if (platform === 'youtube') {
       deletedPlatformId = targetUser.youtubeId;
@@ -530,8 +534,10 @@ export class UsersService {
 
       // 선택된 로고 + 닉네임 제거
       const youtube = await this.youtubeRepository.findOne(targetUser.youtubeId);
-      targetPlatformLogo = this.resizeingYoutubeLogo(youtube.youtubeLogo);
-      targetPlatformNickname = youtube.youtubeTitle;
+      if (youtube) {
+        targetPlatformLogo = this.resizeingYoutubeLogo(youtube.youtubeLogo);
+        targetPlatformNickname = youtube.youtubeTitle;
+      }
     }
 
     // 플랫폼 연결 정보 삭제 및 대표 프로필 사진|닉네임이 해당 플랫폼의 프로필사진|닉네임인 경우 함께 삭제

--- a/server/test.Dockerfile
+++ b/server/test.Dockerfile
@@ -1,0 +1,66 @@
+# Note that
+# build 명령어는 언제나 Truepoint root 폴더에서 빌드를 실행하여야 합니다.
+# 명령어는 다음과 같습니다.
+# docker build -t <DOCKER_NAME>/<IMAGE_NAME>:<IMAGE_TAG> -f ./server/Dockerfile .
+
+# ############################################
+# Step 1
+FROM node:12.18.3-alpine AS builder
+
+WORKDIR /tp-mvp-server
+
+# timezone 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# server, shared 복사
+COPY server /tp-mvp-server/server
+COPY shared /tp-mvp-server/shared
+
+# 최상위 packagejson , yarn.lock 복사
+COPY package.json .
+COPY yarn.lock .
+
+# monorepo 내부 패키지 (shared) 를 포함한 모든 디펜던시 설치
+RUN yarn install --pure-lockfile --non-interactive
+
+## Build shared 패키지
+WORKDIR /tp-mvp-server/shared
+RUN yarn build
+
+## Build server 패키지
+WORKDIR /tp-mvp-server/server
+RUN yarn build
+
+# ############################################
+# Step 2
+FROM node:12.18.3-alpine AS api
+
+WORKDIR /truepoint
+
+ENV NODE_ENV test
+# timezone 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# shared
+COPY --from=builder /tp-mvp-server/shared/package.json /truepoint/shared/package.json
+COPY --from=builder /tp-mvp-server/shared/dist /truepoint/shared/dist
+
+# server
+COPY --from=builder /tp-mvp-server/server/package.json /truepoint/server/package.json
+COPY --from=builder /tp-mvp-server/server/dist /truepoint/server/dist
+COPY --from=builder /tp-mvp-server/server/tsconfig.build.json /truepoint/server/tsconfig.build.json
+COPY --from=builder /tp-mvp-server/server/tsconfig.json /truepoint/server/tsconfig.json
+
+# root dependencies
+COPY package.json .
+COPY yarn.lock .
+
+RUN yarn install --pure-lockfile --non-interactive
+
+WORKDIR /truepoint/server
+
+## application 실행
+EXPOSE 3000
+CMD ["yarn", "start:prod"]

--- a/server/test.Dockerfile
+++ b/server/test.Dockerfile
@@ -66,4 +66,5 @@ WORKDIR /truepoint/server
 
 ## application 실행
 EXPOSE 3000
-CMD ["NODE_ENV=test", "yarn", "start:prod"]
+ENV NODE_ENV test
+CMD ["yarn", "start:prod"]

--- a/server/test.Dockerfile
+++ b/server/test.Dockerfile
@@ -24,6 +24,9 @@ COPY yarn.lock .
 # monorepo 내부 패키지 (shared) 를 포함한 모든 디펜던시 설치
 RUN yarn install --pure-lockfile --non-interactive
 
+## 테스트 환경변수 설정
+ENV NODE_ENV test
+
 ## Build shared 패키지
 WORKDIR /tp-mvp-server/shared
 RUN yarn build
@@ -63,4 +66,4 @@ WORKDIR /truepoint/server
 
 ## application 실행
 EXPOSE 3000
-CMD ["yarn", "start:prod"]
+CMD ["NODE_ENV=test", "yarn", "start:prod"]


### PR DESCRIPTION
- Twitch 연동 해제 X - (testtest 아이디에서 특정적으로 나타남)
    - ⇒ **원인 파악**: testtest에 연동된 twitchId에 대한 정보가 PlatformTwitch 내부에 없어 생긴 문제.
        1. 왜 PlatformTwtich에 없었는가? → User에 임의로 넣었기 때문으로 보임.

        ⇒ **수정**: PlatformTwitch 에 정보가 없으면 User에 (아/트/유)Id 제거만 진행되도록 수정

    - [x]  수정 완료
- Twitch / Youtube 연동 X - 리디렉션 URI localhost:3000 으로 설정되어 있는 문제
    - ⇒ **원인 파악**:
        1. test 환경에서 redirectionURI에 url이 잘못 들어가는 문제.
        도커 빌드 과정 에서 NODE_ENV 주입이 올바르게 되었나 확인 필요.

            ⇒ 수정: API서버 github actions workflow 수정 및 API서버 Dockerfile 수정

            - [x]  수정 완료

        2. 유튜브 / 트위치 redirectionURI 설정이 잘 못 되어있는 문제.

        ⇒ 수정: 유튜브 / 트위치 API console에서 redirectionURI 변경

        - [x]  수정 완료
- Afreeca 연동 X - 연동한 아프리카 유저가 누군지 몰라, 트루포인트 ID로 들어가도록 처리되어 있음.
    - ⇒ 변경점: 아프리카 연동 방법 강구 ( 아이디를 입력 받는다거나 ) CBT 에서는 아프리카 연동 기능 없고, 참여 의사 조사시 희망 아이디를 받아 트루포인트 내부에서 아이디 생성해 주는 방식으로 진행한다고 함. 이때, 아프리카 연동도 진행 (아프리카Id를 채워 넣는다). **( 기획자로부터의 답변 )**

        ⇒ 수정: 아프리카 연동 임시 제거

        - [x]  수정 완료