### PR TITLE
[TP-SPRINT #3 버그수정] 트위치 채팅 수집 간헐적으로 수집되지 않는 방송 원인규명

### DIFF
--- a/aws/cdk/lib/prod/truepoint-collectorDB-stack.ts
+++ b/aws/cdk/lib/prod/truepoint-collectorDB-stack.ts
@@ -61,7 +61,7 @@ export class WhileTrueCollectorStack extends BaseStack {
     const collectorDBInstace = new rds.DatabaseInstance(this, `${ID_PREFIX}DBInstance`, {
       vpc,
       engine: dbEngine,
-      // masterUsername: 'whiletrue',
+      credentials: { username: 'whiletrue' },
       instanceIdentifier: `${ID_PREFIX}RDS-${dbEngine.engineType}`,
       databaseName: ID_PREFIX,
       // *********************************************
@@ -168,7 +168,7 @@ export class WhileTrueCollectorStack extends BaseStack {
     );
     const twitchtvChatsTaskDef = new ecs.FargateTaskDefinition(
       this, `${ID_PREFIX}${TWITCH_CHAT_COLLECTOR_FAMILY_NAME}TaskDef`,
-      { family: TWITCH_CHAT_COLLECTOR_FAMILY_NAME, cpu: 512, memoryLimitMiB: 1024 },
+      { family: TWITCH_CHAT_COLLECTOR_FAMILY_NAME, cpu: 1024, memoryLimitMiB: 2048 },
     );
     twitchtvChatsTaskDef.addContainer(
       `${ID_PREFIX}${TWITCH_CHAT_COLLECTOR_FAMILY_NAME}Container`, {

--- a/aws/cdk/lib/prod/truepoint-collectorDB-stack.ts
+++ b/aws/cdk/lib/prod/truepoint-collectorDB-stack.ts
@@ -61,7 +61,6 @@ export class WhileTrueCollectorStack extends BaseStack {
     const collectorDBInstace = new rds.DatabaseInstance(this, `${ID_PREFIX}DBInstance`, {
       vpc,
       engine: dbEngine,
-      credentials: { username: 'whiletrue' },
       instanceIdentifier: `${ID_PREFIX}RDS-${dbEngine.engineType}`,
       databaseName: ID_PREFIX,
       // *********************************************


### PR DESCRIPTION
## 현상

트위치 채팅 수집 간헐적으로 수집되지 않는 방송이 있는 것으로 확인됨.

## 원인

CloudWatch 로그 확인 결과, CPU 사용량 초과 등으로 주기적으로 꺼졌다가 켜진 것으로 보임.

- 배포하는 도커 컨테이너 CPU 최대 사용량
![image](https://user-images.githubusercontent.com/43170520/102460336-2ed04e00-408a-11eb-8d0b-5266e60274a1.png)

- 배포하는 도커 컨테이너 CPU 평균 사용량
![image](https://user-images.githubusercontent.com/43170520/102460357-368ff280-408a-11eb-965f-f12474375265.png)


## 해결방법

- 트위치 채팅 수집기 ECS 서비스에 AutoScaling 기능을 추가해, 사용량이 많을 때 컨테이너를 다중으로 띄워둔다
    - 이 방식에서 생길 수 있는 문제점.
        1. 문제점 ⇒ Socket 서버의 양방향 연결 방식이 AutoScaling을 통해 컨테이너가 여러 개 띄워졌을 때 중복으로 연결되어 한 크리에이터의 채팅을 두번 세번 수집하지는 않을지 의문

            ⇒ socket.io-redis를 통해 메시지를 서로 공유하는 방식 → socket서버가아닌 socket-client인 트위치 챗봇에 올바르게 적용이 되는가?

## 수정 처리

- 일단, TwitchTargetStreamer 의 필요없는 인원은 제외하여 채팅 수집 양 자체를 줄임. ( CBT 접촉 스트리머 + channelName이 있는 스트리머 400명가량 )
- 일단, 수직 확장 진행. → 컨테이너의 CPU를 1024로 수정
    - 시간대 또는 사용량에 맞추어 오토스케일링 적용은 socket 의 auto scaling 에 대하여 좀 더 공부한 뒤 진행