### PR TITLE
Joni 최근 방송 정보 조회 (유튜브 편집점 제공 페이지) - 백엔드

### DIFF
--- a/server/src/collector-entities/afreeca/targetStreamers.entity.ts
+++ b/server/src/collector-entities/afreeca/targetStreamers.entity.ts
@@ -2,7 +2,9 @@ import {
   Column, CreateDateColumn, Entity, UpdateDateColumn,
 } from 'typeorm';
 
-@Entity('AfreecaTargetStreamers')
+@Entity('AfreecaTargetStreamers', {
+  database: 'WhileTrueCollector',
+})
 export class AfreecaTargetStreamersEntity {
   @Column({ primary: true })
   creatorId: string;

--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -1,28 +1,33 @@
 import express from 'express';
 import {
-  Controller, Request, Post, UseGuards, Get, Query,
+  // UseGuards,
+  Controller, Request, Post, Get, Query,
   HttpException, HttpStatus, Res, BadRequestException,
   Body, Req, Delete, UseFilters, InternalServerErrorException, ForbiddenException,
 } from '@nestjs/common';
 import { CheckCertificationDto } from '@truepoint/shared/dist/dto/auth/checkCertification.dto';
 import { LogoutDto } from '@truepoint/shared/dist/dto/auth/logout.dto';
 import { LinkPlatformRes } from '@truepoint/shared/dist/res/LinkPlatformRes.interface';
-import { LocalAuthGuard } from '../../guards/local-auth.guard';
 import { ValidationPipe } from '../../pipes/validation.pipe';
 import { AuthService } from './auth.service';
-import { LogedInExpressRequest, UserLoginPayload } from '../../interfaces/logedInUser.interface';
+import {
+  LogedInExpressRequest,
+  // UserLoginPayload 
+} from '../../interfaces/logedInUser.interface';
 import { CertificationInfo } from '../../interfaces/certification.interface';
 import { UsersService } from '../users/users.service';
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 import { PlatformTwitchEntity } from '../users/entities/platformTwitch.entity';
 import { PlatformYoutubeEntity } from '../users/entities/platformYoutube.entity';
-import { YoutubeLinkGuard } from '../../guards/youtube-link.guard';
-import { TwitchLinkGuard } from '../../guards/twitch-link.guard';
 import { AfreecaLinker } from './strategies/afreeca.linker';
 import { TwitchLinkExceptionFilter } from './filters/twitch-link.filter';
 import { YoutubeLinkExceptionFilter } from './filters/youtube-link.filter';
 import { AfreecaLinkExceptionFilter } from './filters/afreeca-link.filter';
 import getFrontHost from '../../utils/getFrontHost';
+// 가드 임시 주석처리
+// import { LocalAuthGuard } from '../../guards/local-auth.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { YoutubeLinkGuard } from '../../guards/youtube-link.guard';
+// import { TwitchLinkGuard } from '../../guards/twitch-link.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -43,31 +48,32 @@ export class AuthController {
     return { success: false };
   }
 
+  // 로그인 컨트롤러 임시 주석처리
   // 로그인 컨트롤러
-  @UseGuards(LocalAuthGuard)
-  @Post('login')
-  async login(
-    @Body('stayLogedIn') stayLogedIn: boolean,
-    @Request() req: express.Request,
-    @Res() res: express.Response,
-  ): Promise<void> {
-    const user = req.user as UserLoginPayload;
-    const {
-      accessToken, refreshToken,
-    } = await this.authService.login(user, stayLogedIn);
+  // @UseGuards(LocalAuthGuard)
+  // @Post('login')
+  // async login(
+  //   @Body('stayLogedIn') stayLogedIn: boolean,
+  //   @Request() req: express.Request,
+  //   @Res() res: express.Response,
+  // ): Promise<void> {
+  //   const user = req.user as UserLoginPayload;
+  //   const {
+  //     accessToken, refreshToken,
+  //   } = await this.authService.login(user, stayLogedIn);
 
-    // *************************************
-    // 연동된 플랫폼(아/트/유) 유저 정보 최신화 작업
+  //   // *************************************
+  //   // 연동된 플랫폼(아/트/유) 유저 정보 최신화 작업
 
-    // 아프리카의 경우 아직 Profile Data를 제공하지 않아 불가능. 2020.12.08 @by hwasurr
-    // if (user.afreecaId) this.usersService.refreshAfreecaInfo(user.afreecaId);
-    if (user.twitchId) this.usersService.refreshTwitchInfo(user.twitchId);
-    if (user.youtubeId) this.usersService.refreshYoutubeInfo(user.youtubeId);
+  //   // 아프리카의 경우 아직 Profile Data를 제공하지 않아 불가능. 2020.12.08 @by hwasurr
+  //   // if (user.afreecaId) this.usersService.refreshAfreecaInfo(user.afreecaId);
+  //   if (user.twitchId) this.usersService.refreshTwitchInfo(user.twitchId);
+  //   if (user.youtubeId) this.usersService.refreshYoutubeInfo(user.youtubeId);
 
-    // Set-Cookie 헤더로 refresh_token을 담은 HTTP Only 쿠키를 클라이언트에 심는다.
-    res.cookie('refresh_token', refreshToken, { httpOnly: true });
-    res.send({ access_token: accessToken });
-  }
+  //   // Set-Cookie 헤더로 refresh_token을 담은 HTTP Only 쿠키를 클라이언트에 심는다.
+  //   res.cookie('refresh_token', refreshToken, { httpOnly: true });
+  //   res.send({ access_token: accessToken });
+  // }
 
   /**
    * 패스워드가 맞는지 확인하여 true , false를 반환하는 컨트롤러로,
@@ -75,7 +81,7 @@ export class AuthController {
    * @param req 로그인 user 정보를 포함한 요청 객체
    * @param password 패스워드 plain 문자열
    */
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @Post('check-pw')
   async checkPw(
     @Req() req: LogedInExpressRequest,
@@ -128,7 +134,7 @@ export class AuthController {
    * @param id 연동하는 플랫폼의 고유 아이디
    */
   @Post('link')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   async platformLink(
     @Req() req: LogedInExpressRequest,
     @Body('platform') platform: string, @Body('id') id: string,
@@ -143,7 +149,7 @@ export class AuthController {
    * @param platform 연동 제거할 플랫폼 문자열 twitch|youtube|afreeca 셋 중 하나.
    */
   @Delete('link')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   async deletePlatformLink(
     @Req() req: LogedInExpressRequest, @Body('platform') platform: string,
   ): Promise<string> {
@@ -159,14 +165,14 @@ export class AuthController {
   // *********** Twitch ******************
   // Twitch Link start
   @Get('twitch')
-  @UseGuards(TwitchLinkGuard)
+  // @UseGuards(TwitchLinkGuard)
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   twitch(): void {}
 
   // Twitch oauth Callback url
   @Get('twitch/callback')
   @UseFilters(TwitchLinkExceptionFilter)
-  @UseGuards(TwitchLinkGuard)
+  // @UseGuards(TwitchLinkGuard)
   twitchCallback(
     @Req() req: express.Request,
     @Res() res: express.Response,
@@ -180,13 +186,13 @@ export class AuthController {
   // *********** Youtube ******************
   // Youtube link start
   @Get('youtube')
-  @UseGuards(YoutubeLinkGuard)
+  // @UseGuards(YoutubeLinkGuard)
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   youtube(): void {}
 
   @Get('youtube/callback')
   @UseFilters(YoutubeLinkExceptionFilter)
-  @UseGuards(YoutubeLinkGuard)
+  // @UseGuards(YoutubeLinkGuard)
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   youtubeCallback(
     @Req() req: express.Request,

--- a/server/src/resources/broadcast-info/broadcast-info.controller.ts
+++ b/server/src/resources/broadcast-info/broadcast-info.controller.ts
@@ -1,10 +1,11 @@
 import {
-  Controller, UseGuards, Get, Query, Param,
+  // UseGuards, 
+  Controller, Get, Query, Param,
 } from '@nestjs/common';
 import { StreamDataType } from '@truepoint/shared/dist/interfaces/StreamDataType.interface';
 import { BroadcastDataForDownload } from '@truepoint/shared/dist/interfaces/BroadcastDataForDownload.interface';
 import { SearchCalendarStreams } from '@truepoint/shared/dist/dto/stream-analysis/searchCalendarStreams.dto';
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 
 // service
 import { BroadcastInfoService } from './broadcast-info.service';
@@ -21,7 +22,7 @@ export class BroadcastInfoController {
    * @param findDaysStreamRequest 로그인 유저 아이디, 조회 시작 날짜 00시 00분 , 조회 종료 날짜 23시 59분
    */
   @Get()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard) // 가드 임시 주석처리
   getCompleteStreamsList(@Query(new ValidationPipe())
     findDaysStreamRequest: SearchCalendarStreams): Promise<StreamDataType[]> {
     return this.broadcastService.findDayStreamList(

--- a/server/src/resources/category/category.controller.ts
+++ b/server/src/resources/category/category.controller.ts
@@ -1,7 +1,8 @@
 import {
-  Controller, UseGuards, Get,
+  // UseGuards,
+  Controller, Get,
 } from '@nestjs/common';
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 
 // service
 import { CategoryService } from './category.service';
@@ -18,7 +19,7 @@ export class CategoryController {
    * 카테고리 데이터 전체 조회 라우터
    */
   @Get()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   findAllCategories(): Promise<CategoryEntity[]> {
     return this.categoryService.findAll();
   }

--- a/server/src/resources/notification/notification.controller.ts
+++ b/server/src/resources/notification/notification.controller.ts
@@ -1,6 +1,7 @@
 import {
+  // UseGuards, 
   Controller, Get, Body, Patch, Query,
-  UseGuards, Post, UseInterceptors,
+  Post, UseInterceptors,
   ClassSerializerInterceptor,
 } from '@nestjs/common';
 
@@ -10,7 +11,7 @@ import { NotificationGetRequest } from '@truepoint/shared/dist/dto/notification/
 import { NotificationPostRequest } from '@truepoint/shared/dist/dto/notification/notificationPost.dto';
 
 // Gaurd
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 // service
 import { NotificationService } from './notification.service';
 // entity
@@ -27,7 +28,7 @@ export class NotificationController {
    * @param changeReadState 유저아이디와 인덱스
    */
   @Patch()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   updateNotificationReadState(
     @Body(new ValidationPipe()) changeReadState: ChangeReadState,
   ): Promise<boolean> {

--- a/server/src/resources/stream-analysis/entities/streams.entity.ts
+++ b/server/src/resources/stream-analysis/entities/streams.entity.ts
@@ -2,7 +2,7 @@ import {
   Entity, Column, PrimaryColumn,
 } from 'typeorm';
 import { Stream } from '@truepoint/shared/dist/interfaces/Stream.interface';
-@Entity({ name: 'Streams' })
+@Entity({ name: 'Streams', database: 'TruepointDev' })
 export class StreamsEntity implements Stream {
   @PrimaryColumn()
   streamId: string;

--- a/server/src/resources/stream-analysis/stream-analysis.controller.ts
+++ b/server/src/resources/stream-analysis/stream-analysis.controller.ts
@@ -1,7 +1,7 @@
 import {
+  // UseGuards,
   Controller, Get, ParseArrayPipe,
-  Query, UseGuards,
-  Post, Body,
+  Query, Post, Body,
 } from '@nestjs/common';
 // shared dto , interfaces
 import { SearchEachS3StreamData } from '@truepoint/shared/dist/dto/stream-analysis/searchS3StreamData.dto';
@@ -18,7 +18,7 @@ import { StreamAnalysisService } from './stream-analysis.service';
 // // pipe
 // import { ValidationPipe } from '../../pipes/validation.pipe';
 // guard
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 // Entity
 import { StreamsEntity } from './entities/streams.entity';
 
@@ -33,7 +33,7 @@ export class StreamAnalysisController {
   * @param findInfoRequest 2개의 방송을 배열 형태로 받는다.
   */
   @Get('streams')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   getStreamsInfo(
     @Query('streams', new ParseArrayPipe({ items: SearchEachStream })) findInfoRequest: SearchStreamInfoByStreamId,
   ): Promise<StreamAnalysisResType[]> {
@@ -46,7 +46,7 @@ export class StreamAnalysisController {
    * @param compare 분석 가능 방송 리스트
    */
   @Post('periods')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   async getPeriodsStreamsInfo(
   @Body('base', new ParseArrayPipe({ items: EachStream })) base: EachStream[],
   @Body('compare', new ParseArrayPipe({ items: EachStream })) compare: EachStream[],
@@ -60,7 +60,7 @@ export class StreamAnalysisController {
   * @param s3Request S3 조회 규격 방송 리스트
   */
   @Get('period')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   getTest(
     @Query('streams', new ParseArrayPipe({ items: SearchEachS3StreamData }))
       s3Request: SearchEachS3StreamData[],
@@ -73,7 +73,7 @@ export class StreamAnalysisController {
   * @param findUserStatisticRequest 유저 아이디 
   */
   @Get('user-statistics')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   getUserStatisticsInfo(
     @Query() findUserStatisticRequest: SearchUserStatisticData,
   ): Promise<StreamsEntity[]> {

--- a/server/src/resources/users/users.controller.ts
+++ b/server/src/resources/users/users.controller.ts
@@ -1,6 +1,7 @@
 import {
+  // UseGuards,
   Controller, Post, Body, Get, UseInterceptors,
-  ClassSerializerInterceptor, Query, Patch, UseGuards, Req, ForbiddenException, Delete, Param,
+  ClassSerializerInterceptor, Query, Patch, Req, ForbiddenException, Delete, Param,
 } from '@nestjs/common';
 // DTOs
 import { CreateUserDto } from '@truepoint/shared/dist/dto/users/createUser.dto';
@@ -10,7 +11,7 @@ import { ProfileImages } from '@truepoint/shared/dist/res/ProfileImages.interfac
 import { UpdateUserDto } from '@truepoint/shared/dist/dto/users/updateUser.dto';
 import { ChannelNames } from '@truepoint/shared/dist/res/ChannelNames.interface';
 import { BriefInfoDataResType } from '@truepoint/shared/dist/res/BriefInfoData.interface';
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 import { ValidationPipe } from '../../pipes/validation.pipe';
 import { UsersService } from './users.service';
 import { AuthService } from '../auth/auth.service';
@@ -33,7 +34,7 @@ export class UsersController {
    * @param userId 유저 정보를 열람하고자 하는 유저의 아이디
    */
   @Get()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @UseInterceptors(ClassSerializerInterceptor)
   async findUser(
     @Req() req: LogedInExpressRequest,
@@ -49,7 +50,7 @@ export class UsersController {
    * @param userId 연동된 플랫폼 프로필 이미지를 열람하고자 하는 유저 아이디
    */
   @Get('profile-images')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @UseInterceptors(ClassSerializerInterceptor)
   async findUserProfileImages(
     @Req() req: LogedInExpressRequest,
@@ -65,7 +66,7 @@ export class UsersController {
    * @param userId 연동된 플랫폼 닉네임/채널명을 열람하고자 하는 유저 아이디
    */
   @Get('platform-names')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @UseInterceptors(ClassSerializerInterceptor)
   async findLinkedChannelNames(
     @Req() req: LogedInExpressRequest,
@@ -81,7 +82,7 @@ export class UsersController {
    * @param updateUserDto 변경할 유저 정보 Data Transfer Object
    */
   @Patch()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @UseInterceptors(ClassSerializerInterceptor)
   async updateUser(
     @Req() req: LogedInExpressRequest,
@@ -95,7 +96,7 @@ export class UsersController {
   }
 
   @Delete()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @UseInterceptors(ClassSerializerInterceptor)
   async deleteUser(
     @Req() req: LogedInExpressRequest,
@@ -150,7 +151,7 @@ export class UsersController {
     output  : [{userId, targetUserId, startAt, endAt}, {userId, targetUserId, startAt, endAt} ... ]
   */
   @Get('/subscribe-users')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   getUserValidSubscribeInfo(
     @Query(new ValidationPipe()) subscribeUsersRequest: SubscribeUsers,
   ): Promise<{validUserList: SubscribeEntity[]; inValidUserList: SubscribeEntity[]}> {

--- a/server/src/resources/users/users.controller.ts
+++ b/server/src/resources/users/users.controller.ts
@@ -180,7 +180,7 @@ export class UsersController {
 
   /**
    * 유투브 편집점 페이지 편집점 제공 목록 요청
-   * GET /users/editing-point-list/:platform
+   * GET /users/highlight-point-list/:platform
    * 플랫폼에 따라 최근 방송 종료순으로 
    * 크리에이터 활동명, userId, 최근방송제목, 최근방송종료시간, 플랫폼 정보를 반환한다
    * 
@@ -196,11 +196,11 @@ export class UsersController {
       nickname: string // 크리에이터 활동명
    * }[]
    */
-  @Get('/editing-point-list/:platform')
-  getEditingPointList(
+  @Get('/highlight-point-list/:platform')
+  getHighlightPointList(
     @Param('platform') platform: 'afreeca'|'twitch',
   ): Promise<any[]> {
-    return this.usersService.getEditingPointList(platform);
+    return this.usersService.getHighlightPointList(platform);
   }
 
   // 회원 가입

--- a/server/src/resources/users/users.controller.ts
+++ b/server/src/resources/users/users.controller.ts
@@ -1,6 +1,6 @@
 import {
   Controller, Post, Body, Get, UseInterceptors,
-  ClassSerializerInterceptor, Query, Patch, UseGuards, Req, ForbiddenException, Delete,
+  ClassSerializerInterceptor, Query, Patch, UseGuards, Req, ForbiddenException, Delete, Param,
 } from '@nestjs/common';
 // DTOs
 import { CreateUserDto } from '@truepoint/shared/dist/dto/users/createUser.dto';
@@ -175,6 +175,31 @@ export class UsersController {
   @Get('/brief-info-list')
   getAllUserBriefInfoList(): Promise<BriefInfoDataResType> {
     return this.usersService.getAllUserBriefInfoList();
+  }
+
+  /**
+   * 유투브 편집점 페이지 편집점 제공 목록 요청
+   * GET /users/editing-point-list/:platform
+   * 플랫폼에 따라 최근 방송 종료순으로 
+   * 크리에이터 활동명, userId, 최근방송제목, 최근방송종료시간, 플랫폼 정보를 반환한다
+   * 
+   * @param platform 'afreeca' | 'twitch'
+   * 
+   * @return EditingPointListResType[]
+   * {   
+   *  creatorId: string, // 크리에이터 ID(아프리카아이디 || 트위치아이디)
+      platform: string, // 플랫폼 'afreeca' | 'twitch'
+      userId: string,   // userId
+      title: string,   // 가장 최근 방송 제목
+      endDate: Date,   // 가장 최근 방송의 종료시간
+      nickname: string // 크리에이터 활동명
+   * }[]
+   */
+  @Get('/editing-point-list/:platform')
+  getEditingPointList(
+    @Param('platform') platform: 'afreeca'|'twitch',
+  ): Promise<any[]> {
+    return this.usersService.getEditingPointList(platform);
   }
 
   // 회원 가입

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -323,7 +323,7 @@ export class UsersService {
       nickname: string // 크리에이터 활동명
    * }[]
    */
-  async getEditingPointList(platform: 'afreeca'|'twitch'): Promise<EditingPointListResType[]> {
+  async getHighlightPointList(platform: 'afreeca'|'twitch'): Promise<EditingPointListResType[]> {
     try {
       const matchingId = `${platform}Id`;
       return await this.streamsRepository.createQueryBuilder('streams')

--- a/shared/res/EditingPointListResType.interface.ts
+++ b/shared/res/EditingPointListResType.interface.ts
@@ -1,0 +1,8 @@
+export interface EditingPointListResType{
+  creatorId: string,
+  platform: string,
+  userId: string,
+  title: string,
+  endDate: Date,
+  nickname: string
+}


### PR DESCRIPTION
유투브 편집점 페이지 편집점 제공 목록 요청
   * GET /users/editing-point-list/:platform
   * platform: 'twitch' | 'afreeca'

해당 플랫폼의 크리에이터 활동명, 가장최근방송 종료시간, 가장최근방송 제목, userId, creatorId, 플랫폼 정보를 
최근 방송종료 내림차순으로 반환합니다.

아프리카 방송의 경우 다른 db의 테이블과 조인하려 했으나 제 이해도 부족으로 실패했습니다.
지금은 AfreecaTargetStreamers 테이블에 있는 값을 Users,  PlatformAfreeca에 복붙하여 
필요한 값을 받아올 수 있게 해뒀습니다.