### PR TITLE
Joni 인방 랭킹 지표 백엔드 Read

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -24,6 +24,7 @@ import { HealthCheckModule } from './resources/health-check/healthcheck.module';
 import { BroadcastInfoModule } from './resources/broadcast-info/broadcast-info.module';
 import { CbtModule } from './resources/cbt/cbt.module';
 import { CommunityBoardModule } from './resources/communityBoard/communityBoard.module';
+import { RankingsModule } from './resources/rankings/rankings.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true, load: [loadConfig] }),
@@ -50,6 +51,7 @@ import { CommunityBoardModule } from './resources/communityBoard/communityBoard.
     BroadcastInfoModule,
     CbtModule,
     CommunityBoardModule,
+    RankingsModule,
   ],
 })
 export class AppModule { }

--- a/server/src/resources/rankings/entities/rankings.entity.ts
+++ b/server/src/resources/rankings/entities/rankings.entity.ts
@@ -18,6 +18,9 @@ export class RankingsEntity implements Rankings {
   @Column()
   creatorName: string;
 
+  @Column()
+  title: string;
+
   @CreateDateColumn({ type: 'timestamp', comment: '테이블에 삽입된 날짜' })
   createDate: Date;
 

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -17,7 +17,7 @@ export class RankingsController {
      admire: MonthlyRankData[]
    * }
    */
-  @Get('/monthly-scores')
+  @Get('monthly-scores')
   getMonthlyScoresRank(): Promise<any> {
     return this.rankingsService.getMonthlyScoresRank();
   }
@@ -33,8 +33,22 @@ export class RankingsController {
     cuss: TopTenRankData[],
     }
    */
-  @Get('/top-ten')
+  @Get('top-ten')
   getTopTenRank(): Promise<any> {
     return this.rankingsService.getTopTenRank();
+  }
+
+  /**
+   * 플랫폼별 상위 10인 시청자수 합 비교
+   * GET /rankings/daily-total-viewers
+   * @return
+   * {
+   *  twitch: { data: [], total : number},
+   *  afreeca: { data: [], total: number}
+   * }
+   */
+  @Get('daily-total-viewers')
+  getDailyTotalViewers(): Promise<any> {
+    return this.rankingsService.getDailyTotalViewers();
   }
 }

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -9,6 +9,21 @@ export class RankingsController {
 
   @Get()
   test(): Promise<any> {
-    return this.rankingsService.getTopTenViewerByPlatform();
+    return this.rankingsService.test();
+  }
+
+  /**
+   * 지난 월간 웃음/감탄/답답함점수 랭킹목록 반환
+   * GET /rankings/monthly-scores
+   * @return 
+   * {
+   * smile: MonthlyRankData[],
+     frustrate: MonthlyRankData[],
+     admire: MonthlyRankData[]
+   * }
+   */
+  @Get('/monthly-scores')
+  getMonthlyScores(): Promise<any> {
+    return this.rankingsService.getMonthlyScores();
   }
 }

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -1,4 +1,6 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller, Get, Param, ParseIntPipe,
+} from '@nestjs/common';
 import { RankingsService } from './rankings.service';
 
 @Controller('rankings')
@@ -50,5 +52,33 @@ export class RankingsController {
   @Get('daily-total-viewers')
   getDailyTotalViewers(): Promise<any> {
     return this.rankingsService.getDailyTotalViewers();
+  }
+
+  /**
+   * 주간 시청자수 랭킹
+   * GET /rankings/weekly-viewers
+   * 최근 7일 내 날짜별 트위치,아프리카 시청자수 상위 10인의 시청자수 총합
+   * @return 
+   * {
+   * afreeca: [{date:'2021-3-4',totalViewer:'23432'}, {date:'2021-3-3',totalViewer:'1235'}, ... ],
+   * twitch: [{date:'2021-3-4',totalViewer:'1234'}, {date:'2021-3-3',totalViewer:'3432'}, ... ]
+   * }
+   */
+  @Get('weekly-viewers')
+  getWeeklyViewers(): Promise<any> {
+    return this.rankingsService.getWeeklyViewers();
+  }
+
+  /**
+   * // 가짜데이터 넣기위해 임시로 사용..
+   * @param dayDiff 0: 오늘날짜로 createDate입력, 1: 1일전 날짜로 createDate입력...
+   * @param platform 'afreeca'|'twitch'
+   */
+  @Get('insert/:platform/:dayDiff')
+  insert(
+    @Param('dayDiff', ParseIntPipe) dayDiff: number,
+    @Param('platform') platform: string,
+  ): any {
+    return this.rankingsService.insert(platform, dayDiff);
   }
 }

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { RankingsService } from './rankings.service';
+
+@Controller('rankings')
+export class RankingsController {
+  constructor(
+    private readonly rankingsService: RankingsService,
+  ) {}
+
+  @Get()
+  test(): Promise<any> {
+    return this.rankingsService.getTopTenViewerByPlatform();
+  }
+}

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -10,7 +10,7 @@ export class RankingsController {
   ) {}
 
   /**
-   * 지난 월간 웃음/감탄/답답함점수 랭킹목록 반환
+   * 지난 월간 웃음/감탄/답답함점수 랭킹목록 반환 -> 지난 월간 웃음점수/감탄점수/답답함점수 막대그래프에 사용
    * GET /rankings/monthly-scores
    * @return 
    * {
@@ -25,8 +25,12 @@ export class RankingsController {
   }
 
   /**
-   * 반응별 랭킹 top 10
+   * 반응별 랭킹 top 10 
+   * 감탄점수, 웃음점수, 답답함점수, 욕점수 상위 10명과 
+   * 10명의 최근 7개 방송 점수 데이터 반환
+   * 
    * GET /rankings/top-ten
+   * 
    * @return
    * {
     smile: TopTenRankData[],
@@ -41,12 +45,14 @@ export class RankingsController {
   }
 
   /**
-   * 플랫폼별 상위 10인 시청자수 합 비교
+   * 플랫폼별 상위 10인 시청자수 합 비교 -> 플랫폼별 상위 10인의 시청자수 합 카드에 사용
+   *
    * GET /rankings/daily-total-viewers
+   * 
    * @return
    * {
-   *  twitch: { data: [], total : number},
-   *  afreeca: { data: [], total: number}
+   *  twitch: { data: [{maxViewer: number; creatorName: string; creatorId: string; }], total : number},
+   *  afreeca: { data: [maxViewer: number; creatorName: string; creatorId: string; ], total: number}
    * }
    */
   @Get('daily-total-viewers')
@@ -70,8 +76,11 @@ export class RankingsController {
   }
 
   /**
-   * // 가짜데이터 넣기위해 임시로 사용..
-   * @param dayDiff 0: 오늘날짜로 createDate입력, 1: 1일전 날짜로 createDate입력...
+   * 가짜데이터 넣기위해 임시로 만듦
+   * 해당 플랫폼에
+   * 오늘날짜로부터 dayDiff만큼 떨어진 날짜로 
+   * 약 10명의 방송데이터를 생성한다
+   * @param dayDiff 0: 오늘날짜로 createDate입력, 1: 1일전 날짜로 createDate입력
    * @param platform 'afreeca'|'twitch'
    */
   @Get('insert/:platform/:dayDiff')

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -24,6 +24,14 @@ export class RankingsController {
 
   /**
    * 반응별 랭킹 top 10
+   * GET /rankings/top-ten
+   * @return
+   * {
+    smile: TopTenRankData[],
+    admire: TopTenRankData[],
+    frustrate: TopTenRankData[],
+    cuss: TopTenRankData[],
+    }
    */
   @Get('/top-ten')
   getTopTenRank(): Promise<any> {

--- a/server/src/resources/rankings/rankings.controller.ts
+++ b/server/src/resources/rankings/rankings.controller.ts
@@ -7,11 +7,6 @@ export class RankingsController {
     private readonly rankingsService: RankingsService,
   ) {}
 
-  @Get()
-  test(): Promise<any> {
-    return this.rankingsService.test();
-  }
-
   /**
    * 지난 월간 웃음/감탄/답답함점수 랭킹목록 반환
    * GET /rankings/monthly-scores
@@ -23,7 +18,15 @@ export class RankingsController {
    * }
    */
   @Get('/monthly-scores')
-  getMonthlyScores(): Promise<any> {
-    return this.rankingsService.getMonthlyScores();
+  getMonthlyScoresRank(): Promise<any> {
+    return this.rankingsService.getMonthlyScoresRank();
+  }
+
+  /**
+   * 반응별 랭킹 top 10
+   */
+  @Get('/top-ten')
+  getTopTenRank(): Promise<any> {
+    return this.rankingsService.getTopTenRank();
   }
 }

--- a/server/src/resources/rankings/rankings.module.ts
+++ b/server/src/resources/rankings/rankings.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RankingsController } from './rankings.controller';
+import { RankingsService } from './rankings.service';
+import { RankingsEntity } from './entities/rankings.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([
+    RankingsEntity,
+  ])],
+  controllers: [RankingsController],
+  providers: [RankingsService],
+})
+export class RankingsModule {}

--- a/server/src/resources/rankings/rankings.service.ts
+++ b/server/src/resources/rankings/rankings.service.ts
@@ -15,15 +15,25 @@ interface MonthlyRankData{
   avgScore: number;
 }
 
-interface TopTenRankData{
-  creatorId: string;
-  id: number;
-  platform: string;
-  creatorName: string;
-  title: string;
-  streamDate: Date;
-  smileScore: number;
-}
+/**
+    smileScore 부분은 ScoreColumn이 키로 들어가는데
+    string union type을 키로 사용하는 방법 찾아봐야함
+    [key:ScoreColumn]: number; 처럼 사용할 수 없음
+ */
+// interface TopTenRankData{
+//  rankingData : {
+//    creatorId: string;
+//    id: number;
+//    platform: string;
+//    creatorName: string;
+//    title: string;
+//    streamDate: Date;
+//    [key:ScoreColumn]: number;
+//  }
+//  weeklyTrends : {
+//    [key:string] :  { createDate: string; [key:ScoreColumn]: number }[]}
+//  }
+// }
 
 interface DailyTotalViewerData{
   creatorId: string;
@@ -112,7 +122,15 @@ export class RankingsService {
    * 
    * @param column "smileScore" | "frustrateScore" | "admireScore" | "cussScore"
    * @return {
-      rankingData : TopTenRankData[]
+      rankingData : {
+                     creatorId: string;
+                     id: number;
+                     platform: string;
+                     creatorName: string;
+                     title: string;
+                     streamDate: Date;
+                     [key:ScoreColumn]: number;
+                   }
       weeklyTrends : {[key:string] : [ { createDate: string; [key:ScoreColumn]: number }]}
    }
    */

--- a/server/src/resources/rankings/rankings.service.ts
+++ b/server/src/resources/rankings/rankings.service.ts
@@ -143,15 +143,15 @@ export class RankingsService {
   async getTopTenByColumn(column: ScoreColumn): Promise<any> {
     const rankingData = await getConnection()
       .createQueryBuilder()
-      .from(RankingsEntity, 't1')
+      .from(RankingsEntity, 'T1')
       .select([
-        `t1.${column} AS ${column}`,
-        't1.id AS id',
-        't1.creatorId AS creatorId',
-        't1.creatorName AS creatorName',
-        't1.title AS title',
-        't1.createDate AS createDate',
-        't1.platform AS platform',
+        `T1.${column} AS ${column}`,
+        'T1.id AS id',
+        'T1.creatorId AS creatorId',
+        'T1.creatorName AS creatorName',
+        'T1.title AS title',
+        'T1.createDate AS createDate',
+        'T1.platform AS platform',
       ])
       .addFrom((subQuery) => subQuery // 최근 24시간 내 방송을 creatorId별로 그룹화하여 creatorId와 최대점수를 구한 테이블(t2)
         .select([
@@ -161,10 +161,10 @@ export class RankingsService {
         .from(RankingsEntity, 'rankings')
         .groupBy('rankings.creatorId')
         .where('createDate >= DATE_SUB(NOW(), INTERVAL 1 DAY)'),
-      't2')
-      .where('t1.creatorId = t2.creatorId')
-      .andWhere(`t1.${column} = t2.maxScore`) // 최대점수를 가지는 레코드의 정보를 가져온다(t2와 t1의 creatorId와 점수가 같은 레코드)
-      .orderBy(`t1.${column}`, 'DESC')
+      'T2')
+      .where('T1.creatorId = T2.creatorId')
+      .andWhere(`T1.${column} = T2.maxScore`) // 최대점수를 가지는 레코드의 정보를 가져온다(t2와 T1의 creatorId와 점수가 같은 레코드)
+      .orderBy(`T1.${column}`, 'DESC')
       .take(10)
       .getRawMany();
 
@@ -195,26 +195,26 @@ export class RankingsService {
     const data = await getConnection()
       .createQueryBuilder()
       .select([
-        't.creatorId',
-        't.createDate',
-        `t.${column}`,
+        'T.creatorId',
+        'T.createDate',
+        `T.${column}`,
       ])
       .from((subQuery) => subQuery
-        .from(RankingsEntity, 'r')
+        .from(RankingsEntity, 'R')
         .select([
-          `r.${column} AS ${column}`,
-          'DATE_FORMAT(r.createDate,"%Y-%c-%e") AS createDate',
-          'r.creatorId AS creatorId',
-          'RANK() OVER(PARTITION BY r.creatorId ORDER BY r.createDate DESC) AS rnk',
+          `R.${column} AS ${column}`,
+          'DATE_FORMAT(R.createDate,"%Y-%c-%e") AS createDate',
+          'R.creatorId AS creatorId',
+          'RANK() OVER(PARTITION BY R.creatorId ORDER BY R.createDate DESC) AS rnk',
         ])
-        .where(`r.creatorId IN ('${topTenCreatorIds.join("','")}')`),
-      't')
-      .where('t.rnk <= 7')
+        .where(`R.creatorId IN ('${topTenCreatorIds.join("','")}')`),
+      'T')
+      .where('T.rnk <= 7')
       .getRawMany();
 
     // 가져온 데이터를 { creatorId: [ {createDate: "2021-3-5", cussScore: 9.861}, ... ], } 형태로 변환함
     const result = topTenCreatorIds.reduce((obj, key) => ({ ...obj, [key]: [] }), {});
-    data.forEach((d) => {
+    data.reverse().forEach((d) => {
       const { creatorId, createDate } = d;
       result[creatorId].push({ createDate, [column]: d[column] });
     });

--- a/server/src/resources/rankings/rankings.service.ts
+++ b/server/src/resources/rankings/rankings.service.ts
@@ -1,14 +1,89 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { getConnection, Repository } from 'typeorm';
+import {
+  // getConnection, 
+  Repository,
+} from 'typeorm';
 import { RankingsEntity } from './entities/rankings.entity';
 
+interface MonthlyRankData{
+  creatorName: string;
+  creatorId: string;
+  platform: 'twitch' | 'afreeca';
+  avgScore: number;
+}
 @Injectable()
 export class RankingsService {
   constructor(
     @InjectRepository(RankingsEntity)
     private readonly rankingsRepository: Repository<RankingsEntity>,
   ) {}
+
+  /**
+   * 월간 월간 웃음/감탄/답답함 점수 순위 구할 때 사용할 기본 쿼리
+   * 
+   * 현재 기준으로 1개월 내에 생성된 데이터에 대하여
+   * creatorName, creatorId, platform정보를 
+   * 5개 가져오도록 한다
+   */
+  private monthlyScoreBaseQuery = this.rankingsRepository
+    .createQueryBuilder('rankings')
+    .select('creatorName')
+    .addSelect('creatorId')
+    .addSelect('platform')
+    .where('createDate >= DATE_SUB(NOW(), INTERVAL 1 MONTH)')
+    .groupBy('creatorName')
+    .take(5);
+
+  /**
+   * monthlyScoreBaseQuery 기본 쿼리를 바탕으로
+   * 기준 컬럼(웃음점수, 감탄점수, 답답함점수)에 따라
+   * 월간 평균점수컬럼을 추가하고, 
+   * 해당 평균점수 별로 내림차순 정렬하여 값을 가져온다
+   * @param column 'smileScore'|'frustrateScore'|'admireScore'
+   * @return MonthlyRankData[]
+    {
+      "creatorName": "랄로",
+      "creatorId": "fkffh",
+      "platform": "twitch",
+      "avgScore": 9.3595
+    }[]
+   */
+  async getMonthlyRank(column: 'smileScore'|'frustrateScore'|'admireScore'): Promise<MonthlyRankData[]> {
+    const decimalPlace = 2;// 평균점수 소수점 2자리까지만
+    try {
+      return await this.monthlyScoreBaseQuery.clone()
+        .addSelect(`TRUNCATE(AVG(${column}),${decimalPlace})`, 'avgScore')
+        .orderBy('avgScore', 'DESC')
+        .getRawMany();
+    } catch (error) {
+      throw new InternalServerErrorException('error in getMonthlySmileRank');
+    }
+  }
+
+  /**
+   * 지난 월간 웃음/감탄/답답함 평균점수 상위 5명씩 뽑아서 반환
+   * @return 
+   * {
+   * smile: MonthlyRankData[],
+     frustrate: MonthlyRankData[],
+     admire: MonthlyRankData[]
+   * }
+   */
+  async getMonthlyScores(): Promise<{
+    smile: MonthlyRankData[],
+    frustrate: MonthlyRankData[],
+    admire: MonthlyRankData[]
+  }> {
+    const smile = await this.getMonthlyRank('smileScore');
+    const frustrate = await this.getMonthlyRank('frustrateScore');
+    const admire = await this.getMonthlyRank('admireScore');
+    return {
+      smile,
+      frustrate,
+      admire,
+    };
+  }
 
   async test(): Promise<any> {
     return this.rankingsRepository.find();
@@ -21,21 +96,6 @@ export class RankingsService {
       .addSelect('rankings.creatorName')
       .addSelect('rankings.viewer')
       .orderBy('rankings.viewer', 'DESC');
-
-    // .from((subQuery) => subQuery
-    //   .select('r.*')
-    //   .from(RankingsEntity, 'r')
-    //   .orderBy('r.createDate', 'DESC'), 'rankings')
-    // .groupBy('rankings.creatorName')
-    // .getSql();
-    // const d = await getConnection().createQueryBuilder()
-    //   .select('sub.creatorName')
-    //   .from((qb) => qb
-    //     .select('r.createDate', 'r.creatorName')
-    //     .from(RankingsEntity, 'r')
-    //     .orderBy('r.createDate', 'DESC'), 'sub')
-    //   .getMany();
-
     return data;
   }
 }

--- a/server/src/resources/rankings/rankings.service.ts
+++ b/server/src/resources/rankings/rankings.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { getConnection, Repository } from 'typeorm';
+import { RankingsEntity } from './entities/rankings.entity';
+
+@Injectable()
+export class RankingsService {
+  constructor(
+    @InjectRepository(RankingsEntity)
+    private readonly rankingsRepository: Repository<RankingsEntity>,
+  ) {}
+
+  async test(): Promise<any> {
+    return this.rankingsRepository.find();
+  }
+
+  async getTopTenViewerByPlatform(): Promise<any> {
+    const data = await this.rankingsRepository
+      .createQueryBuilder('rankings')
+      .select('rankings.createDate')
+      .addSelect('rankings.creatorName')
+      .addSelect('rankings.viewer')
+      .orderBy('rankings.viewer', 'DESC');
+
+    // .from((subQuery) => subQuery
+    //   .select('r.*')
+    //   .from(RankingsEntity, 'r')
+    //   .orderBy('r.createDate', 'DESC'), 'rankings')
+    // .groupBy('rankings.creatorName')
+    // .getSql();
+    // const d = await getConnection().createQueryBuilder()
+    //   .select('sub.creatorName')
+    //   .from((qb) => qb
+    //     .select('r.createDate', 'r.creatorName')
+    //     .from(RankingsEntity, 'r')
+    //     .orderBy('r.createDate', 'DESC'), 'sub')
+    //   .getMany();
+
+    return data;
+  }
+}

--- a/server/src/resources/rankings/rankings.service.ts
+++ b/server/src/resources/rankings/rankings.service.ts
@@ -6,13 +6,24 @@ import {
 } from 'typeorm';
 import { RankingsEntity } from './entities/rankings.entity';
 
+type ScoreColumn = 'smileScore'|'frustrateScore'|'admireScore'|'cussScore';
 interface MonthlyRankData{
   creatorName: string;
   creatorId: string;
   platform: 'twitch' | 'afreeca';
   avgScore: number;
 }
-type ScoreColumn = 'smileScore'|'frustrateScore'|'admireScore'|'cussScore';
+
+interface TopTenRankData{
+  creatorId: string;
+  platform: string;
+  creatorName: string;
+  title: string;
+  streamDate: Date;
+  smileScore: number;
+  rank: string; // "1"처럼 들어옴
+}
+
 @Injectable()
 export class RankingsService {
   constructor(
@@ -86,37 +97,73 @@ export class RankingsService {
     };
   }
 
-  async getTopTenByColumn(column: ScoreColumn): Promise<any> {
-    return [];
-  }
-
-  async getTopTenRank(): Promise<any> {
-    // 웃음점수 상위 10명 
-    // group by로 뽑아온 값중에 가장큰 값(max)의 상태값을 가져오기 http://b1ix.net/87
-    const data = await getConnection()
+  /**
+   * column 으로 들어온 값에 따라
+   * 감탄점수/웃음점수/답답함점수/욕점수 상위 10명(플랫폼 무관)의 데이터
+   * @return TopTenRankData[]
+   * {
+      creatorId: string;
+      platform: string;
+      creatorName: string;
+      title: string;
+      streamDate: Date;
+      smileScore: number;
+      rank: string; // "1"처럼 들어옴
+    }[]
+   * @param column "smileScore" | "frustrateScore" | "admireScore" | "cussScore"
+   */
+  async getTopTenByColumn(column: ScoreColumn): Promise<TopTenRankData[]> {
+    // group by로 뽑아온 값중에 가장큰 값(max)의 상태값을 가져오기 http://b1ix.net/87 참고함
+    return getConnection()
       .createQueryBuilder()
-      .select([
-        't1.id AS id',
-        't1.creatorId AS creatorId',
-        't1.creatorName AS creatorName',
-        't1.platform AS platform',
-        't1.createDate AS createDate',
-        't1.smileScore AS smileScore'])
-      .addSelect('ROW_NUMBER () OVER (ORDER BY t1.smileScore DESC)', 'rank')
+      .select(`t1.${column}`, `${column}`)
+      .addSelect('t1.creatorId', 'creatorId')
+      .addSelect('t1.creatorName', 'creatorName')
+      .addSelect('t1.title', 'title')
+      .addSelect('t1.streamDate', 'streamDate')
+      .addSelect('t1.platform', 'platform')
+      .addSelect(`ROW_NUMBER () OVER (ORDER BY t1.${column} DESC)`, 'rank') // 랭크 "1" 이렇게 들어옴
       .from(RankingsEntity, 't1')
       .addFrom((subQuery) => subQuery
-        .addSelect('MAX(t2.smileScore)', 'maxScore')
+        .addSelect(`MAX(t2.${column})`, 'maxScore')
         .addSelect('t2.creatorId', 'creatorId')
         .from(RankingsEntity, 't2')
         .groupBy('t2.creatorName'),
       // .where('createDate >= DATE_SUB(NOW(), INTERVAL 1 DAY)'), // 최근 24시간에 대해서
       't2')
       .where('t1.creatorId = t2.creatorId')
-      .andWhere('t1.smileScore = t2.maxScore')
-      // .orderBy('smileScore', 'DESC')
+      .andWhere(`t1.${column} = t2.maxScore`)
       .take(10)
       .getRawMany();
+  }
 
-    return data;
+  /**
+   * 감탄점수/웃음점수/답답함점수/욕점수 상위 10명 뽑아서 반환
+   * @return 
+   * {
+   * smile: TopTenRankData[],
+    admire: TopTenRankData[],
+    frustrate: TopTenRankData[],
+    cuss: TopTenRankData[],
+   * }
+   */
+  async getTopTenRank(): Promise<{
+    smile: TopTenRankData[],
+    admire: TopTenRankData[],
+    frustrate: TopTenRankData[],
+    cuss: TopTenRankData[],
+  }> {
+    // 웃음점수 상위 10명 
+    const smile = await this.getTopTenByColumn('smileScore');
+    // 감탄점수 상위 10명
+    const admire = await this.getTopTenByColumn('admireScore');
+    // 답답함점수 상위 10명
+    const frustrate = await this.getTopTenByColumn('frustrateScore');
+    // 욕점수 상위 10명
+    const cuss = await this.getTopTenByColumn('cussScore');
+
+    return {
+      smile, admire, frustrate, cuss,
+    };
   }
 }

--- a/server/src/resources/rankings/rankings.service.ts
+++ b/server/src/resources/rankings/rankings.service.ts
@@ -17,12 +17,12 @@ interface MonthlyRankData{
 
 interface TopTenRankData{
   creatorId: string;
+  id: number;
   platform: string;
   creatorName: string;
   title: string;
   streamDate: Date;
   smileScore: number;
-  rank: string; // "1"처럼 들어옴
 }
 
 interface DailyTotalViewerData{
@@ -56,7 +56,6 @@ export class RankingsService {
 
   /**
    * monthlyScoreBaseQuery 기본 쿼리를 바탕으로
-   * 기준 컬럼(웃음점수, 감탄점수, 답답함점수)에 따라
    * 월간 평균점수컬럼을 추가하고, 
    * 해당 평균점수 별로 내림차순 정렬하여 값을 가져온다
    * @param column 'smileScore'|'frustrateScore'|'admireScore'
@@ -69,7 +68,7 @@ export class RankingsService {
     }[]
    */
   async getMonthlyRankByColumn(column: ScoreColumn): Promise<MonthlyRankData[]> {
-    const decimalPlace = 2;// 평균점수 소수점 2자리까지만
+    const decimalPlace = 2;// 평균점수 소수점 2자리까 자른다
     try {
       return await this.monthlyScoreBaseQuery.clone()
         .addSelect(`TRUNCATE(AVG(${column}),${decimalPlace})`, 'avgScore')
@@ -81,7 +80,7 @@ export class RankingsService {
   }
 
   /**
-   * 지난 월간 웃음/감탄/답답함 평균점수 상위 5명씩 뽑아서 반환
+   * 지난 월간 웃음/감탄/답답함 평균점수 상위 5명씩 뽑아서 반환 -> 지난 월간 웃음점수/감탄점수/답답함점수 막대그래프에 사용
    * @return 
    * {
    * smile: MonthlyRankData[],
@@ -105,21 +104,20 @@ export class RankingsService {
   }
 
   /**
-   * column 으로 들어온 값에 따라
-   * 감탄점수/웃음점수/답답함점수/욕점수 상위 10명(플랫폼 무관)의 데이터
-   * @return TopTenRankData[]
-   * {
-      creatorId: string;
-      platform: string;
-      creatorName: string;
-      title: string;
-      streamDate: Date;
-      smileScore: number;
-    }[]
+   * 24시간 내 해당 점수 상위 10명의 방송정보를 뽑아내는 함수
+   * 
+   * 최근 24시간 내 방송에 대해 크리에이터별로 최고 점수를 구한 테이블(t2)을 만들고
+   * rankings테이블(t1)에서 최고 점수(t2.maxScore)인 데이터를 가져와
+   * 점수순으로 내림차순하여 10개를 가지고온다
+   * 
    * @param column "smileScore" | "frustrateScore" | "admireScore" | "cussScore"
+   * @return {
+      rankingData : TopTenRankData[]
+      weeklyTrends : {[key:string] : [ { createDate: string; [key:ScoreColumn]: number }]}
+   }
    */
   async getTopTenByColumn(column: ScoreColumn): Promise<any> {
-    const data = await getConnection()
+    const rankingData = await getConnection()
       .createQueryBuilder()
       .from(RankingsEntity, 't1')
       .select([
@@ -131,13 +129,13 @@ export class RankingsService {
         't1.createDate AS createDate',
         't1.platform AS platform',
       ])
-      .addFrom((subQuery) => subQuery // 최근 24시간 내 방송을 creatorId별로 그룹화하여 creatorId와 최대점수를 구한다 => t2
+      .addFrom((subQuery) => subQuery // 최근 24시간 내 방송을 creatorId별로 그룹화하여 creatorId와 최대점수를 구한 테이블(t2)
         .select([
-          `MAX(t2.${column}) AS maxScore`,
-          't2.creatorId AS creatorId',
+          `MAX(rankings.${column}) AS maxScore`,
+          'rankings.creatorId AS creatorId',
         ])
-        .from(RankingsEntity, 't2')
-        .groupBy('t2.creatorId')
+        .from(RankingsEntity, 'rankings')
+        .groupBy('rankings.creatorId')
         .where('createDate >= DATE_SUB(NOW(), INTERVAL 1 DAY)'),
       't2')
       .where('t1.creatorId = t2.creatorId')
@@ -146,60 +144,89 @@ export class RankingsService {
       .take(10)
       .getRawMany();
 
-    const topTenCreatorIds = data.map((d) => d.creatorId);
+    // 상위 10명 크리에이터의 아이디를 뽑아낸다
+    const topTenCreatorIds = rankingData.map((d) => d.creatorId);
+    // 상위 10명 크리에이터의 최근 7개 방송 점수 동향을 구함
+    const weeklyTrends = await this.getTopTenTrendsByColumn(topTenCreatorIds, column);
 
-    const series = await getConnection()
+    return {
+      rankingData,
+      weeklyTrends,
+    };
+  }
+
+  /**
+   * 상위 10인의 creatorId를 받아와 해당 방송인의 최근 7개방송 날짜와 점수를 찾는다
+   * 
+   * Rankings 테이블에서 상위 10인 creatorId인 데이터에 대하여
+   * 해당 점수, 날짜, creatorId, 순위(크리에이터별로 묶어서 최신순으로 매김 - 최근 7개 방송을 가져오기 위해서) 가지고 있는 테이블(t)를 만든다
+   * 테이블 t에 대하여 순위가 7 이하인 값들(=최근 7개 방송 데이터)을 가져온다
+   * 
+   * @param topTenCreatorIds 상위 10인의 creatorId array
+   * @param column 기준 점수 컬럼 "smileScore" | "frustrateScore" | "admireScore" | "cussScore"
+   * @return {[key:string] : [ { createDate: string; [key:ScoreColumn]: number }]}
+   * 예시: { creatorId: [ {createDate: "2021-3-5", cussScore: 9.861}, ... ], }
+   */
+  async getTopTenTrendsByColumn(topTenCreatorIds: string[], column: ScoreColumn): Promise<any> {
+    const data = await getConnection()
       .createQueryBuilder()
-      .select(['t.*'])
+      .select([
+        't.creatorId',
+        't.createDate',
+        `t.${column}`,
+      ])
       .from((subQuery) => subQuery
         .from(RankingsEntity, 'r')
         .select([
           `r.${column} AS ${column}`,
-          'r.createDate AS createDate',
+          'DATE_FORMAT(r.createDate,"%Y-%c-%e") AS createDate',
           'r.creatorId AS creatorId',
-          'RANK() OVER(PARTITION BY r.creatorName ORDER BY r.createDate DESC) AS rnk',
-        ]),
+          'RANK() OVER(PARTITION BY r.creatorId ORDER BY r.createDate DESC) AS rnk',
+        ])
+        .where(`r.creatorId IN ('${topTenCreatorIds.join("','")}')`),
       't')
-      .where(`t.creatorId IN ('${topTenCreatorIds.join("','")}')`)
-      .andWhere('t.rnk <= 7')
+      .where('t.rnk <= 7')
       .getRawMany();
 
-    return {
-      data,
-      series,
-    };
+    // 가져온 데이터를 { creatorId: [ {createDate: "2021-3-5", cussScore: 9.861}, ... ], } 형태로 변환함
+    const result = topTenCreatorIds.reduce((obj, key) => ({ ...obj, [key]: [] }), {});
+    data.forEach((d) => {
+      const { creatorId, createDate } = d;
+      result[creatorId].push({ createDate, [column]: d[column] });
+    });
+
+    return result;
   }
 
   /**
-   * 감탄점수/웃음점수/답답함점수/욕점수 상위 10명 뽑아서 반환
-   * @return 
-   * {
-   * smile: TopTenRankData[],
-    admire: TopTenRankData[],
-    frustrate: TopTenRankData[],
-    cuss: TopTenRankData[],
-   * }
+   * 감탄점수/웃음점수/답답함점수/욕점수 상위 10명 뽑아서 반환 -> 반응별랭킹 TOP 10에 사용
+   * @return  { smile: TopTenRankData[],admire: TopTenRankData[],frustrate: TopTenRankData[],cuss: TopTenRankData[]}
    */
   async getTopTenRank(): Promise<any> {
-    // // 웃음점수 상위 10명 
-    // const smile = await this.getTopTenByColumn('smileScore');
-    // // // 감탄점수 상위 10명
-    // const admire = await this.getTopTenByColumn('admireScore');
-    // // 답답함점수 상위 10명
-    // const frustrate = await this.getTopTenByColumn('frustrateScore');
+    // 웃음점수 상위 10명 
+    const smile = await this.getTopTenByColumn('smileScore');
+    // // 감탄점수 상위 10명
+    const admire = await this.getTopTenByColumn('admireScore');
+    // 답답함점수 상위 10명
+    const frustrate = await this.getTopTenByColumn('frustrateScore');
     // 욕점수 상위 10명
     const cuss = await this.getTopTenByColumn('cussScore');
 
     return {
-      // smile, admire, frustrate, 
-      cuss,
+      smile, admire, frustrate, cuss,
     };
   }
 
   /**
-   * 최근 24시간 내 플랫폼 별 
-   * 시청자 수 상위 10인의 최대 시청자 수,활동명,creatorId
+   * Rankings테이블에서 
+   * 해당 플랫폼이면서 최근 24시간 내 방송에 대하여
+   * creatorId별로 그룹화하여 최대 시청자수 구하고,
+   * 최대시청자수 내림차순으로 정렬하여 
+   * 10개의 데이터(최대시청자수 상위10인)의 데이터를 가져옴
+   * 
+   * 시청자 수 상위 10인의 최대 시청자 수, 활동명, creatorId
    * && 해당 플랫폼의 상위10인 총 시청자수 합 반환
+   * 
    * @param platform 'twitch'|'afreeca'
    * @return
    * {
@@ -216,9 +243,11 @@ export class RankingsService {
   > {
     const data = await this.rankingsRepository
       .createQueryBuilder('rankings')
-      .select('MAX(rankings.viewer)', 'maxViewer')
-      .addSelect('rankings.creatorName', 'creatorName')
-      .addSelect('rankings.creatorId', 'creatorId')
+      .select([
+        'MAX(rankings.viewer) AS maxViewer',
+        'rankings.creatorName AS creatorName',
+        'rankings.creatorId AS creatorId',
+      ])
       .where('rankings.platform =:platform', { platform })
       .andWhere('createDate >= DATE_SUB(NOW(), INTERVAL 1 DAY)') // 최근 24시간에 대해서
       .groupBy('rankings.creatorId')
@@ -232,12 +261,14 @@ export class RankingsService {
   }
 
   /**
-   * 최근 24시간 내 플랫폼별 최대시청자 10인의 데이터와, 
-   * 최대시청자10인의 시청자합을 플랫폼별로 반환
+   * 최근 24시간 내 플랫폼별 최대시청자 10인의 총 시청자수 합 & 개별 최대시청자 정보 반환 
+   * -> 플랫폼별 상위 10인의 시청자수 합 카드에 사용
    * @return 
    * {
-   *  twitch: { data: [], total : number},
-   *  afreeca: { data: [], total: number}
+   *  twitch: { data: [ {"maxViewer": 12248, "creatorName": "꽃핀","creatorId": "Rhcvls"}, ...],
+   *            total : number },
+   *  afreeca: { data: [ {"maxViewer": 12248, "creatorName": "꽃핀","creatorId": "Rhcvls"}, ...], 
+   *            total: number }
    * }
    */
   async getDailyTotalViewers(): Promise<any> {
@@ -248,11 +279,14 @@ export class RankingsService {
   }
 
   /**
-   * rankings테이블에서 생성날짜, 최대시청자수로 정렬한 데이터를 크리에이터별, 날짜별로 그룹화하여
-   * 최대시청자 순으로 rank를 매기고,
-   * 상위10인(rank <= 10)이면서 생성날짜가 최근7일 내인 데이터를 생성날짜순으로 정렬하여 가져옴
+   * 주간 시청자수 랭킹 구하는 함수 -> 주간 시청자수 랭킹 카드에 사용됨
    * 
-   * @return 최근 7일 내 날짜별 트위치,아프리카 시청자수 상위 10인의 시청자수 총합
+   * rankings테이블에서 생성날짜가 최근 7일 내인 데이터를
+   * 생성날짜, 최대시청자수로 정렬 & 크리에이터별, 날짜별로 그룹화하여(A),
+   * 최대시청자 순으로 rank를 매기고(B),
+   * 날짜와 해당 날의 상위10인(rank <= 10)의 최대시청자수 총합을 가져와 플랫폼별, 날짜별로 그룹화함
+   * 
+   * @return 최근 7일 내 플랫폼별 & 날짜별 시청자수 상위 10인의 시청자수 총합
    * {
    * afreeca: [{date:'2021-3-4',totalViewer:'23432'}, {date:'2021-3-3',totalViewer:'1235'}, ... ],
    * twitch: [{date:'2021-3-4',totalViewer:'1234'}, {date:'2021-3-3',totalViewer:'3432'}, ... ]
@@ -260,17 +294,18 @@ export class RankingsService {
    */
   async getWeeklyViewers(): Promise<any> {
     const query = `
-    SELECT platform, cdate as "date", SUM(maxViewer) as totalViewer
+    SELECT platform, cdate AS "date", SUM(maxViewer) AS totalViewer
     FROM(
       SELECT A.*, ROW_NUMBER() OVER (partition by cdate, platform order by maxViewer DESC) AS "rank"
-        FROM (
-          SELECT creatorId, createDate, platform, MAX(viewer) as maxViewer, DATE_FORMAT(createDate,"%Y-%c-%e") AS cdate
-          FROM Rankings
-          Group by creatorId, cdate
-          Order by platform, cdate DESC, maxViewer DESC
-        ) AS A
+      FROM (
+        SELECT creatorId, createDate, platform, MAX(viewer) AS maxViewer, DATE_FORMAT(createDate,"%Y-%c-%e") AS cdate
+        FROM Rankings
+        WHERE createDate >= DATE_SUB(NOW(), INTERVAL 1 WEEK)
+        Group by creatorId, cdate
+        Order by platform, cdate DESC, maxViewer DESC
+      ) AS A
     ) AS B
-    where "rank" <= 10 and cdate >= DATE_SUB(NOW(), INTERVAL 1 WEEK)
+    where "rank" <= 10 
     group by platform, cdate
     order by platform, cdate DESC;`;
 
@@ -282,7 +317,16 @@ export class RankingsService {
     return result;
   }
 
-  // 가짜데이터 넣기위해 임시로 사용
+  /**
+   * 가짜데이터 넣기 위해 임시로 만든 함수
+   * 플랫폼별 임의로 10명정도의 크리에이터이름과 아이디를 넣어두고
+   * 랜덤 시청자수와 점수를 생성
+   * 
+   * @param platform 'twitch' | 'afreeca'
+   * @param dayDiff 생성날짜를 오늘로부터 며칠전으로 할 것인지
+   * 0 : 오늘날짜로 생성날짜 지정, 
+   * 1 : 오늘로부터 1일전으로 생성날짜 지정...
+   */
   async insert(platform: string, dayDiff: number): Promise<any> {
     const twitch = [
       { creatorName: '소행성', creatorId: 'thgodtjd' },

--- a/shared/interfaces/Rankings.interface.ts
+++ b/shared/interfaces/Rankings.interface.ts
@@ -7,6 +7,8 @@ export interface Rankings{
 
   creatorName: string;
 
+  title: string;
+
   createDate: Date;
 
   streamDate: Date;


### PR DESCRIPTION
지난 월간 웃음/감탄/답답함점수 랭킹목록 반환 -> 지난 월간 웃음점수/감탄점수/답답함점수 막대그래프에 사용
   * GET /rankings/monthly-scores

반응별 랭킹 top 10 -> 감탄점수, 웃음점수, 답답함점수, 욕점수 상위 10명과 10명의 최근 7개 방송 점수 데이터 반환
   * GET /rankings/top-ten

플랫폼별 상위 10인 시청자수 합 비교 -> 플랫폼별 상위 10인의 시청자수 합 카드에 사용
   * GET /rankings/daily-total-viewers

주간 시청자수 랭킹 -> 주간시청자 꺾은선 그래프에 사용. 최근 7일 내 날짜별 트위치, 아프리카 시청자수 상위 10인의 시청자수 총합
   * GET /rankings/weekly-viewers
   
미흡한 사항
- 반환 타입 정의되어 있지 않음 -> 추후 프론트엔드 작업하면서 추가하겠습니다
- rankings.service안에  getWeeklyViewers 함수에서 raw쿼리 사용 -> 쿼리빌더로 작성하려고 했으나 계속 어디선가 문법 오류가 나고, 제가 그 오류를 찾지 못해서 일단 raw쿼리로 두었습니다. 더 공부한 후에 프론트 작업 하면서 수정하겠습니다