### PR TITLE
인방랭킹 월간 평균 막대 차트 생성

### DIFF
--- a/client/web/package.json
+++ b/client/web/package.json
@@ -20,6 +20,8 @@
     "axios-hooks": "^2.1.0",
     "classnames": "^2.2.6",
     "date-fns": "2.12.0",
+    "highcharts": "^9.0.1",
+    "highcharts-react-official": "^3.0.0",
     "history": "^5.0.0",
     "js-file-download": "^0.4.12",
     "jwt-decode": "^3.0.0-beta.2",

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import useAxios from 'axios-hooks';
+
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+
+import { Typography, Divider } from '@material-ui/core';
+import CenterLoading from '../../../atoms/Loading/CenterLoading';
+
+interface MonthlyScoresItem{
+  creatorName: string;
+  creatorId: string;
+  platform: string;
+  avgScore: number;
+}
+interface MonthlyScoresData{
+  smile: MonthlyScoresItem[],
+  frustrate: MonthlyScoresItem[],
+  admire: MonthlyScoresItem[],
+}
+
+function ScoresBarChart({
+  title, data, loading, column,
+}: {
+  title: string,
+  data: MonthlyScoresItem[],
+  loading: boolean,
+  column? : string
+}) {
+  const chartRef = useRef<{
+    chart: Highcharts.Chart
+    container: React.RefObject<HTMLDivElement>
+  }>(null);
+
+  const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
+    chart: {
+      type: 'column',
+      marginTop: 24,
+      events: {
+        redraw(this: Highcharts.Chart) {
+          // const { series, renderer, xAxis, plotTop } = this;
+          // if (series[0].data.length === 0) return;
+          // console.log('redraw', series[0].data);
+        },
+      },
+    },
+    title: { text: undefined },
+    yAxis: {
+      title: { text: undefined },
+      labels: { enabled: false },
+      max: 10,
+      tickInterval: 1,
+    },
+    plotOptions: {
+      column: {
+        dataLabels: {
+          enabled: true,
+        },
+      },
+    },
+    legend: { enabled: false },
+    series: [],
+  });
+
+  useEffect(() => {
+    if (data.length === 0) return;
+    const creatorNames = data.map((d) => d.creatorName);
+    const scores = data.map((d) => d.avgScore);
+    setChartOptions({
+      xAxis: { categories: creatorNames },
+      series: [{ type: 'column', name: `평균 ${column} 점수`, data: scores }],
+    });
+  }, [column, data]);
+
+  return (
+    <section>
+      <Typography variant="h6">{title}</Typography>
+      <Divider />
+
+      <HighchartsReact
+        ref={chartRef}
+        highcharts={Highcharts}
+        options={chartOptions}
+      />
+      {loading && (
+      <CenterLoading />
+      )}
+
+    </section>
+  );
+}
+
+const useMonthlyScoresRankingStyle = makeStyles((theme: Theme) => createStyles({
+  monthlyScores: {
+    backgroundColor: theme.palette.background.paper,
+    padding: theme.spacing(2),
+  },
+}));
+function MonthlyScoresRankingCard(): JSX.Element {
+  const classes = useMonthlyScoresRankingStyle();
+  const monthlyScoresUrl = useRef<string>('/rankings/monthly-scores');
+  const [{ data, loading }] = useAxios<MonthlyScoresData>(monthlyScoresUrl.current);
+
+  return (
+    <section className={classes.monthlyScores}>
+      <ScoresBarChart
+        title="지난 월간 웃음 점수 순위"
+        data={data?.smile || []}
+        loading={loading}
+        column="웃음"
+      />
+    </section>
+  );
+}
+
+export default MonthlyScoresRankingCard;

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import {
+  makeStyles, createStyles, Theme, useTheme,
+} from '@material-ui/core/styles';
 import useAxios from 'axios-hooks';
 
 import Highcharts from 'highcharts';
@@ -26,15 +28,18 @@ interface PlottablePoint extends Highcharts.Point {
   plotY: number;
 }
 
-function ScoresBarChart({
-  title, data, loading, column, barColor,
-}: {
-  title: string,
+interface ScoresBarChartProps{
+  title?: string,
   data: MonthlyScoresItem[],
-  loading: boolean,
+  loading?: boolean,
   column? : string,
   barColor? : string,
-}) {
+}
+
+function ScoresBarChart({
+  title, data, loading, column, barColor,
+}: ScoresBarChartProps) {
+  const theme = useTheme();
   const chartRef = useRef<{
     chart: Highcharts.Chart
     container: React.RefObject<HTMLDivElement>
@@ -54,7 +59,7 @@ function ScoresBarChart({
           // 별에 그라디언트 넣기 위한 색 설정
           const starColors = [
             { id: 'gold', startColor: '#f5f542', endColor: '#c9a234' }, // 금
-            { id: 'silver', startColor: '#d2d6d5', endColor: '#7f8785' }, // 은
+            { id: 'silver', startColor: '#d2d6d5', endColor: '#7f9090' }, // 은
             { id: 'bronze', startColor: '#ff8800', endColor: '#9f5c02' }, // 동
           ];
 
@@ -110,6 +115,14 @@ function ScoresBarChart({
     },
     legend: { enabled: false },
     series: [],
+    xAxis: {
+      labels: {
+        style: {
+          fontSize: '0.8rem',
+          color: theme.palette.common.black,
+        },
+      },
+    },
   });
 
   useEffect(() => {

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -61,8 +61,8 @@ function ScoresBarChart({
           // 1,2,3 위 금은동 표시
           for (let i = 0; i < 3; i += 1) {
             const point = series[0].data[i] as PlottablePoint;
-            const x = point.plotX; // 별이 표시될 x좌표
-            const y = plotHeight - 20; // 별이 표시될 y 좌표
+            const x = point.plotX + 2; // 별이 표시될 x좌표
+            const y = plotHeight - 15; // 별이 표시될 y 좌표
             const { id: gradientId, startColor, endColor } = starColors[i];
             // 그라디언트 생성
             const gradient = renderer.createElement('linearGradient')
@@ -84,7 +84,7 @@ function ScoresBarChart({
               points: '20,5 25,20 40,20 30,30 35,45 20,35 5,45 10,30 0,20 15,20', // 별의 각 모서리 좌표 x,y
               fill: `url(#${gradientId})`,
               zIndex: 5,
-              transform: `translate(${x},${y}) scale(0.5)`,
+              transform: `translate(${x},${y}) scale(0.4)`,
             }).add();
           }
         },
@@ -104,6 +104,7 @@ function ScoresBarChart({
         },
         borderRadius: 12,
         color: barColor,
+        pointWidth: 30,
       },
 
     },

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -20,7 +20,7 @@ interface MonthlyScoresData{
 const useMonthlyScoresRankingStyle = makeStyles((theme: Theme) => createStyles({
   monthlyScores: {
     backgroundColor: theme.palette.background.paper,
-    padding: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
     '&>*': {
       marginBottom: theme.spacing(2),
     },
@@ -34,21 +34,18 @@ function MonthlyScoresRankingCard(): JSX.Element {
   return (
     <section className={classes.monthlyScores}>
       <ScoresBarChart
-        title="지난 월간 웃음 점수 순위"
         data={data?.smile || []}
         loading={loading}
         column="웃음"
         barColor="rgba(202, 186, 219,0.7)"
       />
       <ScoresBarChart
-        title="지난 월간 감탄 점수 순위"
         data={data?.admire || []}
         loading={loading}
         column="감탄"
         barColor="rgba(162, 221, 195, 0.698)"
       />
       <ScoresBarChart
-        title="지난 월간 답답함 점수 순위"
         data={data?.frustrate || []}
         loading={loading}
         column="답답함"

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -1,16 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import {
-  makeStyles, createStyles, Theme, useTheme,
+  makeStyles, createStyles, Theme,
 } from '@material-ui/core/styles';
 import useAxios from 'axios-hooks';
+import ScoresBarChart from './sub/ScoresBarChart';
 
-import Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
-
-import { Typography, Divider } from '@material-ui/core';
-import CenterLoading from '../../../atoms/Loading/CenterLoading';
-
-interface MonthlyScoresItem{
+export interface MonthlyScoresItem{
   creatorName: string;
   creatorId: string;
   platform: string;
@@ -22,141 +17,13 @@ interface MonthlyScoresData{
   admire: MonthlyScoresItem[],
 }
 
-// https://github.com/highcharts/highcharts/issues/13738
-interface PlottablePoint extends Highcharts.Point {
-  plotX: number;
-  plotY: number;
-}
-
-interface ScoresBarChartProps{
-  title?: string,
-  data: MonthlyScoresItem[],
-  loading?: boolean,
-  column? : string,
-  barColor? : string,
-}
-
-function ScoresBarChart({
-  title, data, loading, column, barColor,
-}: ScoresBarChartProps) {
-  const theme = useTheme();
-  const chartRef = useRef<{
-    chart: Highcharts.Chart
-    container: React.RefObject<HTMLDivElement>
-  }>(null);
-
-  const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
-    chart: {
-      type: 'column',
-      height: 250,
-      events: {
-        redraw(this: Highcharts.Chart) { // redraw이벤트 발생시 === 데이터가 들어왔을때
-          const {
-            series, renderer, plotHeight,
-          } = this;
-          if (series[0].data.length === 0) return;
-
-          // 별에 그라디언트 넣기 위한 색 설정
-          const starColors = [
-            { id: 'gold', startColor: '#f5f542', endColor: '#c9a234' }, // 금
-            { id: 'silver', startColor: '#d2d6d5', endColor: '#7f9090' }, // 은
-            { id: 'bronze', startColor: '#ff8800', endColor: '#9f5c02' }, // 동
-          ];
-
-          // 1,2,3 위 금은동 표시
-          for (let i = 0; i < 3; i += 1) {
-            const point = series[0].data[i] as PlottablePoint;
-            const x = point.plotX + 2; // 별이 표시될 x좌표
-            const y = plotHeight - 15; // 별이 표시될 y 좌표
-            const { id: gradientId, startColor, endColor } = starColors[i];
-            // 그라디언트 생성
-            const gradient = renderer.createElement('linearGradient')
-              .attr({
-                id: gradientId, x1: '0%', y1: '0%', x2: '0%', y2: '100%',
-              }).add(renderer.defs);
-            renderer.createElement('stop')
-              .attr({
-                offset: '0%', style: `stop-color:${startColor}`,
-              }).add(gradient);
-            renderer.createElement('stop')
-              .attr({
-                offset: '100%', style: `stop-color:${endColor}`,
-              }).add(gradient);
-
-            // 별모양 생성
-            const star = renderer.createElement('polygon');
-            star.attr({
-              points: '20,5 25,20 40,20 30,30 35,45 20,35 5,45 10,30 0,20 15,20', // 별의 각 모서리 좌표 x,y
-              fill: `url(#${gradientId})`,
-              zIndex: 5,
-              transform: `translate(${x},${y}) scale(0.4)`,
-            }).add();
-          }
-        },
-      },
-    },
-    title: { text: undefined },
-    yAxis: {
-      title: { text: undefined },
-      labels: { enabled: false },
-      max: 10,
-      tickInterval: 1,
-    },
-    plotOptions: {
-      column: {
-        dataLabels: {
-          enabled: true,
-        },
-        borderRadius: 12,
-        color: barColor,
-        pointWidth: 30,
-      },
-
-    },
-    legend: { enabled: false },
-    series: [],
-    xAxis: {
-      labels: {
-        style: {
-          fontSize: '0.8rem',
-          color: theme.palette.common.black,
-        },
-      },
-    },
-  });
-
-  useEffect(() => {
-    if (data.length === 0) return;
-    const creatorNames = data.map((d) => d.creatorName);
-    const scores = data.map((d) => d.avgScore);
-    setChartOptions({
-      xAxis: { categories: creatorNames },
-      series: [{ type: 'column', name: `평균 ${column} 점수`, data: scores }],
-    });
-  }, [column, data]);
-
-  return (
-    <section>
-      <Typography variant="h6">{title}</Typography>
-      <Divider />
-
-      <HighchartsReact
-        ref={chartRef}
-        highcharts={Highcharts}
-        options={chartOptions}
-      />
-      {loading && (
-      <CenterLoading />
-      )}
-
-    </section>
-  );
-}
-
 const useMonthlyScoresRankingStyle = makeStyles((theme: Theme) => createStyles({
   monthlyScores: {
     backgroundColor: theme.palette.background.paper,
     padding: theme.spacing(2),
+    '&>*': {
+      marginBottom: theme.spacing(2),
+    },
   },
 }));
 function MonthlyScoresRankingCard(): JSX.Element {

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   makeStyles, createStyles, Theme,
 } from '@material-ui/core/styles';
@@ -31,8 +31,7 @@ const useMonthlyScoresRankingStyle = makeStyles((theme: Theme) => createStyles({
 function MonthlyScoresRankingCard(): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
   const classes = useMonthlyScoresRankingStyle();
-  const monthlyScoresUrl = useRef<string>('/rankings/monthly-scores');
-  const [{ data, error, loading }] = useAxios<MonthlyScoresData>(monthlyScoresUrl.current);
+  const [{ data, error, loading }] = useAxios<MonthlyScoresData>('/rankings/monthly-scores');
 
   if (error) {
     console.error(error);

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -3,7 +3,9 @@ import {
   makeStyles, createStyles, Theme,
 } from '@material-ui/core/styles';
 import useAxios from 'axios-hooks';
+import { useSnackbar } from 'notistack';
 import ScoresBarChart from './sub/ScoresBarChart';
+import ShowSnack from '../../../atoms/snackbar/ShowSnack';
 
 export interface MonthlyScoresItem{
   creatorName: string;
@@ -27,10 +29,15 @@ const useMonthlyScoresRankingStyle = makeStyles((theme: Theme) => createStyles({
   },
 }));
 function MonthlyScoresRankingCard(): JSX.Element {
+  const { enqueueSnackbar } = useSnackbar();
   const classes = useMonthlyScoresRankingStyle();
   const monthlyScoresUrl = useRef<string>('/rankings/monthly-scores');
-  const [{ data, loading }] = useAxios<MonthlyScoresData>(monthlyScoresUrl.current);
+  const [{ data, error, loading }] = useAxios<MonthlyScoresData>(monthlyScoresUrl.current);
 
+  if (error) {
+    console.error(error);
+    ShowSnack('월간 점수 데이터를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.', 'error', enqueueSnackbar);
+  }
   return (
     <section className={classes.monthlyScores}>
       <ScoresBarChart

--- a/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/MonthlyScoresRankingCard.tsx
@@ -6,7 +6,6 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
 import { Typography, Divider } from '@material-ui/core';
-import { start } from 'repl';
 import CenterLoading from '../../../atoms/Loading/CenterLoading';
 
 interface MonthlyScoresItem{
@@ -28,12 +27,13 @@ interface PlottablePoint extends Highcharts.Point {
 }
 
 function ScoresBarChart({
-  title, data, loading, column,
+  title, data, loading, column, barColor,
 }: {
   title: string,
   data: MonthlyScoresItem[],
   loading: boolean,
-  column? : string
+  column? : string,
+  barColor? : string,
 }) {
   const chartRef = useRef<{
     chart: Highcharts.Chart
@@ -45,8 +45,7 @@ function ScoresBarChart({
       type: 'column',
       height: 250,
       events: {
-        // http://jsfiddle.net/chemark/s7mmprdt/ : legend redraw 
-        redraw(this: Highcharts.Chart) {
+        redraw(this: Highcharts.Chart) { // redraw이벤트 발생시 === 데이터가 들어왔을때
           const {
             series, renderer, plotHeight,
           } = this;
@@ -103,7 +102,10 @@ function ScoresBarChart({
         dataLabels: {
           enabled: true,
         },
+        borderRadius: 12,
+        color: barColor,
       },
+
     },
     legend: { enabled: false },
     series: [],
@@ -155,6 +157,21 @@ function MonthlyScoresRankingCard(): JSX.Element {
         data={data?.smile || []}
         loading={loading}
         column="웃음"
+        barColor="rgba(202, 186, 219,0.7)"
+      />
+      <ScoresBarChart
+        title="지난 월간 감탄 점수 순위"
+        data={data?.admire || []}
+        loading={loading}
+        column="감탄"
+        barColor="rgba(162, 221, 195, 0.698)"
+      />
+      <ScoresBarChart
+        title="지난 월간 답답함 점수 순위"
+        data={data?.frustrate || []}
+        loading={loading}
+        column="답답함"
+        barColor="rgba(229, 160, 206, 0.726)"
       />
     </section>
   );

--- a/client/web/src/organisms/mainpage/ranking/UserReactionCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/UserReactionCard.tsx
@@ -47,7 +47,7 @@ const useUserReactionStyle = makeStyles((theme: Theme) => createStyles({
   },
 }));
 
-export default function UserReaction(): JSX.Element {
+export default function UserReactionCard(): JSX.Element {
   const classes = useUserReactionStyle();
   const { enqueueSnackbar } = useSnackbar();
   const formRef = useRef<HTMLFormElement>(null);

--- a/client/web/src/organisms/mainpage/ranking/WeeklyViewerRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/WeeklyViewerRankingCard.tsx
@@ -48,6 +48,7 @@ function WeeklyViewerRankingCard(): JSX.Element {
       spacingTop: 24,
       height: 250,
     },
+    credits: { enabled: false },
     title: { text: undefined },
     xAxis: { crosshair: true },
     yAxis: {

--- a/client/web/src/organisms/mainpage/ranking/WeeklyViewerRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/WeeklyViewerRankingCard.tsx
@@ -1,0 +1,136 @@
+import React, {
+  useEffect, useMemo, useState, useRef,
+} from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import * as datefns from 'date-fns';
+import { Divider, Typography } from '@material-ui/core';
+import getPlatformColor from '../../../utils/getPlatformColor';
+
+const useWeeklyViewerStyle = makeStyles((theme: Theme) => createStyles({
+  weeklyViewerContainer: {
+    backgroundColor: theme.palette.background.paper,
+    padding: theme.spacing(2),
+  },
+  weeklyViewerTitle: {
+    padding: theme.spacing(2),
+  },
+}));
+
+interface WeeklyData{
+  date: string;
+  totalViewer: number;
+}
+
+interface WeeklyViewerRankingCardProps {
+  data: {
+    afreeca: WeeklyData[],
+    twitch: WeeklyData[]
+  }
+}
+
+const markerSize = {
+  width: 14,
+  height: 14,
+};
+
+function WeeklyViewerRankingCard(props: WeeklyViewerRankingCardProps): JSX.Element {
+  const classes = useWeeklyViewerStyle();
+  const chartRef = useRef<{
+    chart: Highcharts.Chart
+    container: React.RefObject<HTMLDivElement>
+}>(null);
+  const { data } = props;
+  const afreecaData = useMemo(() => data.afreeca.reverse(), [data]);
+  const twitchData = useMemo(() => data.twitch.reverse(), [data]);
+  const dates = useMemo(() => afreecaData.map((d: WeeklyData) => datefns.format(new Date(d.date), 'MM-dd')), [afreecaData]);
+  const afreecaViewerArray = useMemo(() => afreecaData.map((d: WeeklyData) => d.totalViewer), [afreecaData]);
+  const twitchViewerArray = useMemo(() => twitchData.map((d: WeeklyData) => d.totalViewer), [twitchData]);
+
+  const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
+    chart: {
+      spacingTop: 24,
+    },
+    title: { text: undefined },
+    xAxis: {
+      categories: dates,
+      crosshair: true,
+    },
+    yAxis: {
+      title: { text: undefined },
+      labels: { enabled: false },
+    },
+    legend: {
+      align: 'left',
+      layout: 'vertical',
+      verticalAlign: 'bottom',
+      itemMarginBottom: 30,
+      labelFormat: ' ',
+      margin: 0,
+      symbolWidth: 40,
+      symbolHeight: 20,
+    },
+    series: [
+      {
+        type: 'line',
+        name: '아프리카',
+        data: afreecaViewerArray,
+        color: getPlatformColor('afreeca'),
+        marker: {
+          symbol: 'url(/images/logo/afreecaLogo.png)',
+          ...markerSize,
+        },
+      },
+      {
+        type: 'line',
+        name: '트위치',
+        data: twitchViewerArray,
+        color: getPlatformColor('twitch'),
+        marker: {
+          symbol: 'url(/images/logo/twitchLogo.png)',
+          ...markerSize,
+        },
+      },
+    ],
+    tooltip: {
+      formatter(this: Highcharts.TooltipFormatterContextObject, tooltip: Highcharts.Tooltip) {
+        const { x, points } = this; // x: x축, points: 각 마커에 대응되는 정보
+
+        // const pointsData = points
+        //   ? points.map((point) => `${point.series.name}: ${point.y}m`)
+        //   : [];
+
+        return [`<b>${x}</b>`].concat(
+          points
+            ? points.map((point) => `${point.series.name}: ${point.y}m`) : [],
+        );
+      },
+      shared: true,
+    },
+  });
+
+  useEffect(() => {
+    setChartOptions({
+      series: [
+        { type: 'line', data: afreecaViewerArray },
+        { type: 'line', data: twitchViewerArray },
+      ],
+      xAxis: { categories: dates },
+    });
+  }, [afreecaViewerArray, dates, twitchViewerArray]);
+
+  return (
+    <section className={classes.weeklyViewerContainer}>
+      <Typography variant="h6" className={classes.weeklyViewerTitle}>주간 시청자수 랭킹</Typography>
+      <Divider />
+      <HighchartsReact
+        ref={chartRef}
+        highcharts={Highcharts}
+        options={chartOptions}
+      />
+    </section>
+  );
+}
+
+export default WeeklyViewerRankingCard;

--- a/client/web/src/organisms/mainpage/ranking/WeeklyViewerRankingCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/WeeklyViewerRankingCard.tsx
@@ -2,10 +2,12 @@ import React, {
   useEffect, useMemo, useState, useRef,
 } from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { Divider, Typography } from '@material-ui/core';
+
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import * as datefns from 'date-fns';
-import { Divider, Typography } from '@material-ui/core';
+
 import getPlatformColor from '../../../utils/getPlatformColor';
 import CenterLoading from '../../../atoms/Loading/CenterLoading';
 
@@ -25,31 +27,48 @@ interface WeeklyData{
   totalViewer: number;
 }
 
-interface WeeklyViewerRankingCardProps {
-  data: {
-    afreeca: WeeklyData[],
-    twitch: WeeklyData[]
-  },
-  loading?: boolean
-}
+// 임시데이터 - 백엔드와 연결이후 삭제예정
+const dummyWeeklyData = {
+  afreeca: [
+    { date: '2021-3-5', totalViewer: 134321 },
+    { date: '2021-3-4', totalViewer: 123411 },
+    { date: '2021-3-3', totalViewer: 134531 },
+    { date: '2021-3-2', totalViewer: 121351 },
+    { date: '2021-3-1', totalViewer: 123451 },
+    { date: '2021-2-28', totalViewer: 126421 },
+    { date: '2021-2-27', totalViewer: 134561 },
+  ].reverse(),
+  twitch: [
+    { date: '2021-3-5', totalViewer: 109382 },
+    { date: '2021-3-4', totalViewer: 113452 },
+    { date: '2021-3-3', totalViewer: 124532 },
+    { date: '2021-3-2', totalViewer: 111352 },
+    { date: '2021-3-1', totalViewer: 113452 },
+    { date: '2021-2-28', totalViewer: 116422 },
+    { date: '2021-2-27', totalViewer: 124562 },
+  ].reverse(),
+};
 
 const markerSize = {
   width: 14,
   height: 14,
 };
 
-function WeeklyViewerRankingCard(props: WeeklyViewerRankingCardProps): JSX.Element {
+function WeeklyViewerRankingCard(): JSX.Element {
   const classes = useWeeklyViewerStyle();
   const chartRef = useRef<{
     chart: Highcharts.Chart
     container: React.RefObject<HTMLDivElement>
 }>(null);
-  const { data, loading } = props;
-  const afreecaDataArray = useMemo(() => data.afreeca.reverse(), [data]);
-  const twitchDataArray = useMemo(() => data.twitch.reverse(), [data]);
-  const dates = useMemo(() => afreecaDataArray.map((d: WeeklyData) => datefns.format(new Date(d.date), 'MM-dd')), [afreecaDataArray]);
-  const afreecaViewerData = useMemo(() => afreecaDataArray.map((d: WeeklyData) => d.totalViewer), [afreecaDataArray]);
-  const twitchViewerData = useMemo(() => twitchDataArray.map((d: WeeklyData) => d.totalViewer), [twitchDataArray]);
+
+  const [data, setData] = useState<any>({ afreeca: [], twitch: [] });
+  const [loading, setLoading] = useState<boolean>(true);
+  // const [{loading}, getWeeklyData] = useAxios({ url: '/rankings/weekly-viewers' }, { manual: true });
+  // 백엔드와 연결이후 바로 윗줄 코드와 교체예정
+
+  const dates = useMemo(() => data.afreeca.map((d: WeeklyData) => datefns.format(new Date(d.date), 'MM-dd')), [data.afreeca]);
+  const afreecaViewerData = useMemo(() => data.afreeca.map((d: WeeklyData) => d.totalViewer), [data.afreeca]);
+  const twitchViewerData = useMemo(() => data.twitch.map((d: WeeklyData) => d.totalViewer), [data.twitch]);
 
   const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
     chart: {
@@ -114,6 +133,23 @@ function WeeklyViewerRankingCard(props: WeeklyViewerRankingCardProps): JSX.Eleme
   });
 
   useEffect(() => {
+    const timeoutID = window.setTimeout(() => {
+      setData(dummyWeeklyData);
+      setLoading(false);
+    }, 3000);
+
+    return () => window.clearTimeout(timeoutID);
+
+    // 백엔드 코드 수정후 합칠 예정
+    // getWeeklyData().then((res) => {
+    //   setWeeklyData(res.data);
+    // }).catch((error) => {
+    //   // 에러핸들링
+    //   console.error(error);
+    // });
+  }, []);
+
+  useEffect(() => {
     setChartOptions({
       series: [
         { type: 'line', data: afreecaViewerData },
@@ -121,7 +157,7 @@ function WeeklyViewerRankingCard(props: WeeklyViewerRankingCardProps): JSX.Eleme
       ],
       xAxis: { categories: dates },
     });
-  }, [afreecaViewerData, dates, twitchViewerData]);
+  }, [afreecaViewerData, twitchViewerData, dates]);
 
   return (
     <section className={classes.weeklyViewerContainer}>

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -164,7 +164,7 @@ function ScoresBarChart({
       },
       series: [{ type: 'column', name: `평균 ${column} 점수`, data: scores }],
     });
-  }, [column, data, theme.palette.common.black]);
+  }, [column, creatorNameFontSize, data, theme.palette.common.black]);
 
   return (
     <section className={classes.barChartSection}>

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -109,6 +109,7 @@ function ScoresBarChart({
     container: React.RefObject<HTMLDivElement>
   }>(null);
   const title = useMemo(() => (`지난 월간 ${column} 점수 순위`), [column]);
+  const creatorNameFontSize = useMemo(() => (`${theme.typography.body2.fontSize}`), [theme.typography.body2.fontSize]);
 
   const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
     chart: {
@@ -132,7 +133,7 @@ function ScoresBarChart({
     },
     legend: { enabled: false },
     tooltip: {
-      headerFormat: '<p style="font-size: 0.8rem;">{point.key}</p><br/>',
+      headerFormat: `<p style="font-size: ${creatorNameFontSize};">{point.key}</p><br/>`,
     },
   });
 
@@ -146,7 +147,7 @@ function ScoresBarChart({
         categories: creatorNames,
         labels: {
           style: {
-            fontSize: '0.8rem',
+            fontSize: creatorNameFontSize,
             color: theme.palette.common.black,
           },
         },

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -120,6 +120,7 @@ function ScoresBarChart({
         redraw: markStarByDataOrder, // redraw이벤트 발생시 === 데이터가 들어왔을때 -> 데이터 값에 따라 금은동 표시
       },
     },
+    credits: { enabled: false },
     title: { text: undefined },
     plotOptions: {
       column: {

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTheme } from '@material-ui/core/styles';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+
+import { Typography, Divider } from '@material-ui/core';
+import CenterLoading from '../../../../atoms/Loading/CenterLoading';
+
+import { MonthlyScoresItem } from '../MonthlyScoresRankingCard';
+
+interface ScoresBarChartProps{
+  title?: string,
+  data: MonthlyScoresItem[],
+  loading?: boolean,
+  column? : string,
+  barColor? : string,
+}
+
+// https://github.com/highcharts/highcharts/issues/13738
+interface PlottablePoint extends Highcharts.Point {
+  plotX: number;
+  plotY: number;
+}
+
+function ScoresBarChart({
+  title, data, loading, column, barColor,
+}: ScoresBarChartProps): JSX.Element {
+  const theme = useTheme();
+  const chartRef = useRef<{
+    chart: Highcharts.Chart
+    container: React.RefObject<HTMLDivElement>
+  }>(null);
+
+  const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
+    chart: {
+      type: 'column',
+      spacingTop: 30,
+      height: 250,
+      events: {
+        redraw(this: Highcharts.Chart) { // redraw이벤트 발생시 === 데이터가 들어왔을때
+          const {
+            series, renderer, plotHeight,
+          } = this;
+          if (!series[0] || series[0].data.length === 0) return;
+
+          // 별에 그라디언트 넣기 위한 색 설정
+          const starColors = [
+            { id: 'gold', startColor: '#f5f542', endColor: '#c9a234' }, // 금
+            { id: 'silver', startColor: '#d2d6d5', endColor: '#7f9090' }, // 은
+            { id: 'bronze', startColor: '#ff8800', endColor: '#9f5c02' }, // 동
+          ];
+
+          // 1,2,3 위 금은동 표시
+          for (let i = 0; i < 3; i += 1) {
+            const point = series[0].data[i] as PlottablePoint;
+            const x = point.plotX + 2; // 별이 표시될 x좌표
+            const y = plotHeight; // 별이 표시될 y 좌표
+            const { id: gradientId, startColor, endColor } = starColors[i];
+            // 그라디언트 생성
+            const gradient = renderer.createElement('linearGradient')
+              .attr({
+                id: gradientId, x1: '0%', y1: '0%', x2: '0%', y2: '100%',
+              }).add(renderer.defs);
+            renderer.createElement('stop')
+              .attr({
+                offset: '0%', style: `stop-color:${startColor}`,
+              }).add(gradient);
+            renderer.createElement('stop')
+              .attr({
+                offset: '100%', style: `stop-color:${endColor}`,
+              }).add(gradient);
+
+            // 별모양 생성
+            const star = renderer.createElement('polygon');
+            star.attr({
+              points: '20,5 25,20 40,20 30,30 35,45 20,35 5,45 10,30 0,20 15,20', // 별의 각 모서리 좌표 x,y
+              fill: `url(#${gradientId})`,
+              zIndex: 5,
+              transform: `translate(${x},${y}) scale(0.4)`,
+            }).add();
+          }
+        },
+      },
+    },
+    title: { text: undefined },
+    yAxis: {
+      title: { text: undefined },
+      labels: { enabled: false },
+      max: 10,
+      tickInterval: 1,
+    },
+    plotOptions: {
+      column: {
+        dataLabels: {
+          enabled: true,
+        },
+        borderRadius: 12,
+        color: barColor,
+        pointWidth: 30,
+      },
+
+    },
+    legend: { enabled: false },
+    series: [],
+    xAxis: {
+      labels: {
+        style: {
+          fontSize: '0.8rem',
+          color: theme.palette.common.black,
+        },
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (data.length === 0) return;
+    const creatorNames = data.map((d) => d.creatorName);
+    const scores = data.map((d) => d.avgScore);
+    setChartOptions({
+      xAxis: { categories: creatorNames },
+      series: [{ type: 'column', name: `평균 ${column} 점수`, data: scores }],
+    });
+  }, [column, data]);
+
+  return (
+    <section>
+      <Typography variant="h6">{title}</Typography>
+      <Divider />
+
+      <HighchartsReact
+        ref={chartRef}
+        highcharts={Highcharts}
+        options={chartOptions}
+      />
+      {loading && (
+      <CenterLoading />
+      )}
+
+    </section>
+  );
+}
+
+export default ScoresBarChart;

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -88,6 +88,9 @@ function markStarByDataOrder(this: Highcharts.Chart) {
 }
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
+  barChartSection: {
+    position: 'relative',
+  },
   header: {
     padding: theme.spacing(2),
   },
@@ -160,7 +163,7 @@ function ScoresBarChart({
   }, [column, data, theme.palette.common.black]);
 
   return (
-    <section>
+    <section className={classes.barChartSection}>
       <header className={classes.header}>
         <Typography variant="h6" className={classes.title}>{title}</Typography>
         <Divider />

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -22,6 +22,45 @@ interface PlottablePoint extends Highcharts.Point {
   plotY: number;
 }
 
+/**
+ * 막대그래프 안에 1,2,3위 별 표시
+ * @param renderer Highcharts.SVGRenderer
+ * @param order 금=0, 은=1, 동=2
+ * @param x 별이 표시될 x좌표
+ * @param y 별이 표시될 y좌표
+ */
+function createStar(renderer: Highcharts.SVGRenderer, order: number, x: number, y: number) {
+  // 별에 그라디언트 넣기 위한 색 설정
+  const starColors = [
+    { id: 'gold', startColor: '#f5f542', endColor: '#c9a234' }, // 금
+    { id: 'silver', startColor: '#d2d6d5', endColor: '#7f9090' }, // 은
+    { id: 'bronze', startColor: '#ff8800', endColor: '#9f5c02' }, // 동
+  ];
+  const { id: gradientId, startColor, endColor } = starColors[order];
+  // 그라디언트 생성
+  const gradient = renderer.createElement('linearGradient')
+    .attr({
+      id: gradientId, x1: '0%', y1: '0%', x2: '0%', y2: '100%',
+    }).add(renderer.defs);
+  renderer.createElement('stop')
+    .attr({
+      offset: '0%', style: `stop-color:${startColor}`,
+    }).add(gradient);
+  renderer.createElement('stop')
+    .attr({
+      offset: '100%', style: `stop-color:${endColor}`,
+    }).add(gradient);
+
+  // 별모양 생성
+  const star = renderer.createElement('polygon');
+  star.attr({
+    points: '20,5 25,20 40,20 30,30 35,45 20,35 5,45 10,30 0,20 15,20', // 별의 각 모서리 좌표 x,y
+    fill: `url(#${gradientId})`,
+    zIndex: 5,
+    transform: `translate(${x},${y}) scale(0.4)`,
+  }).add();
+}
+
 function ScoresBarChart({
   title, data, loading, column, barColor,
 }: ScoresBarChartProps): JSX.Element {
@@ -43,41 +82,12 @@ function ScoresBarChart({
           } = this;
           if (!series[0] || series[0].data.length === 0) return;
 
-          // 별에 그라디언트 넣기 위한 색 설정
-          const starColors = [
-            { id: 'gold', startColor: '#f5f542', endColor: '#c9a234' }, // 금
-            { id: 'silver', startColor: '#d2d6d5', endColor: '#7f9090' }, // 은
-            { id: 'bronze', startColor: '#ff8800', endColor: '#9f5c02' }, // 동
-          ];
-
-          // 1,2,3 위 금은동 표시
+          // 1,2,3위에 대해 금은동 별 표시
           for (let i = 0; i < 3; i += 1) {
             const point = series[0].data[i] as PlottablePoint;
             const x = point.plotX + 2; // 별이 표시될 x좌표
             const y = plotHeight; // 별이 표시될 y 좌표
-            const { id: gradientId, startColor, endColor } = starColors[i];
-            // 그라디언트 생성
-            const gradient = renderer.createElement('linearGradient')
-              .attr({
-                id: gradientId, x1: '0%', y1: '0%', x2: '0%', y2: '100%',
-              }).add(renderer.defs);
-            renderer.createElement('stop')
-              .attr({
-                offset: '0%', style: `stop-color:${startColor}`,
-              }).add(gradient);
-            renderer.createElement('stop')
-              .attr({
-                offset: '100%', style: `stop-color:${endColor}`,
-              }).add(gradient);
-
-            // 별모양 생성
-            const star = renderer.createElement('polygon');
-            star.attr({
-              points: '20,5 25,20 40,20 30,30 35,45 20,35 5,45 10,30 0,20 15,20', // 별의 각 모서리 좌표 x,y
-              fill: `url(#${gradientId})`,
-              zIndex: 5,
-              transform: `translate(${x},${y}) scale(0.4)`,
-            }).add();
+            createStar(renderer, i, x, y);
           }
         },
       },
@@ -98,7 +108,6 @@ function ScoresBarChart({
         color: barColor,
         pointWidth: 30,
       },
-
     },
     legend: { enabled: false },
     series: [],

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -131,6 +131,9 @@ function ScoresBarChart({
       },
     },
     legend: { enabled: false },
+    tooltip: {
+      headerFormat: '<p style="font-size: 0.8rem;">{point.key}</p><br/>',
+    },
   });
 
   useEffect(() => {

--- a/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/ScoresBarChart.tsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useTheme } from '@material-ui/core/styles';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
+import {
+  useTheme, createStyles, makeStyles, Theme,
+} from '@material-ui/core/styles';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 // eslint-disable-next-line camelcase
@@ -13,7 +17,6 @@ import { MonthlyScoresItem } from '../MonthlyScoresRankingCard';
 HC_brokenAxis(Highcharts); // yAxis break 사용하기 위해 필요
 
 interface ScoresBarChartProps{
-  title?: string,
   data: MonthlyScoresItem[],
   loading?: boolean,
   column? : string,
@@ -36,8 +39,8 @@ interface PlottablePoint extends Highcharts.Point {
 function createStar(renderer: Highcharts.SVGRenderer, order: number, x: number, y: number) {
   // 별에 그라디언트 넣기 위한 색 설정
   const starColors = [
-    { id: 'gold', startColor: '#f5f542', endColor: '#c9a234' }, // 금
-    { id: 'silver', startColor: '#d2d6d5', endColor: '#7f9090' }, // 은
+    { id: 'gold', startColor: '#ffff00', endColor: '#c9a589' }, // 금
+    { id: 'silver', startColor: '#ebebeb', endColor: '#7f9090' }, // 은
     { id: 'bronze', startColor: '#ff8800', endColor: '#9f5c02' }, // 동
   ];
   const { id: gradientId, startColor, endColor } = starColors[order];
@@ -84,14 +87,25 @@ function markStarByDataOrder(this: Highcharts.Chart) {
   }
 }
 
+const useStyles = makeStyles((theme: Theme) => createStyles({
+  header: {
+    padding: theme.spacing(2),
+  },
+  title: {
+    padding: theme.spacing(2),
+  },
+}));
+
 function ScoresBarChart({
-  title, data, loading, column, barColor,
+  data, loading, column, barColor,
 }: ScoresBarChartProps): JSX.Element {
   const theme = useTheme();
+  const classes = useStyles();
   const chartRef = useRef<{
-    chart: Highcharts.Chart
+    chart: Highcharts.Chart,
     container: React.RefObject<HTMLDivElement>
   }>(null);
+  const title = useMemo(() => (`지난 월간 ${column} 점수 순위`), [column]);
 
   const [chartOptions, setChartOptions] = useState<Highcharts.Options>({
     chart: {
@@ -147,8 +161,10 @@ function ScoresBarChart({
 
   return (
     <section>
-      <Typography variant="h6">{title}</Typography>
-      <Divider />
+      <header className={classes.header}>
+        <Typography variant="h6" className={classes.title}>{title}</Typography>
+        <Divider />
+      </header>
 
       <HighchartsReact
         ref={chartRef}

--- a/client/web/src/pages/mainpage/Ranking.tsx
+++ b/client/web/src/pages/mainpage/Ranking.tsx
@@ -6,6 +6,7 @@ import Footer from '../../organisms/shared/footer/Footer';
 import ProductHero from '../../organisms/mainpage/shared/ProductHero';
 import UserReactionCard from '../../organisms/mainpage/ranking/UserReactionCard';
 import WeeklyViewerRankingCard from '../../organisms/mainpage/ranking/WeeklyViewerRankingCard';
+import MonthlyScoresRankingCard from '../../organisms/mainpage/ranking/MonthlyScoresRankingCard';
 
 const useRankingPageLayout = makeStyles((theme: Theme) => createStyles({
   root: {
@@ -65,9 +66,7 @@ export default function Ranking(): JSX.Element {
               </section>
             </Grid>
             <Grid item xs={4} className={wrapper.right}>
-              <section className={wrapper.monthlyScore}>
-                월간 점수
-              </section>
+              <MonthlyScoresRankingCard />
               <WeeklyViewerRankingCard />
               <UserReactionCard />
             </Grid>

--- a/client/web/src/pages/mainpage/Ranking.tsx
+++ b/client/web/src/pages/mainpage/Ranking.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Container, Grid } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Appbar from '../../organisms/shared/Appbar';
 import Footer from '../../organisms/shared/footer/Footer';
 import ProductHero from '../../organisms/mainpage/shared/ProductHero';
-import UserReaction from '../../organisms/mainpage/ranking/UserReaction';
+import UserReactionCard from '../../organisms/mainpage/ranking/UserReactionCard';
+import WeeklyViewerRankingCard from '../../organisms/mainpage/ranking/WeeklyViewerRankingCard';
 
 const useRankingPageLayout = makeStyles((theme: Theme) => createStyles({
   root: {
@@ -31,10 +32,6 @@ const useRankingPageLayout = makeStyles((theme: Theme) => createStyles({
     background: 'blue',
     height: '300px',
   },
-  weeklyViewer: {
-    background: 'yellow',
-    height: '300px',
-  },
   userReaction: {
     background: 'green',
     height: '300px',
@@ -42,10 +39,40 @@ const useRankingPageLayout = makeStyles((theme: Theme) => createStyles({
 
 }));
 
+const dummyWeeklyData = {
+  afreeca: [
+    { date: '2021-3-5', totalViewer: 134321 },
+    { date: '2021-3-4', totalViewer: 123411 },
+    { date: '2021-3-3', totalViewer: 134531 },
+    { date: '2021-3-2', totalViewer: 121351 },
+    { date: '2021-3-1', totalViewer: 123451 },
+    { date: '2021-2-28', totalViewer: 126421 },
+    { date: '2021-2-27', totalViewer: 134561 },
+  ],
+  twitch: [
+    { date: '2021-3-5', totalViewer: 109382 },
+    { date: '2021-3-4', totalViewer: 113452 },
+    { date: '2021-3-3', totalViewer: 124532 },
+    { date: '2021-3-2', totalViewer: 111352 },
+    { date: '2021-3-1', totalViewer: 113452 },
+    { date: '2021-2-28', totalViewer: 116422 },
+    { date: '2021-2-27', totalViewer: 124562 },
+  ],
+};
+
 export default function Ranking(): JSX.Element {
   const wrapper = useRankingPageLayout();
   const memoAppbar = useMemo(() => <Appbar />, []);
   const memoFooter = useMemo(() => <Footer />, []);
+  const [weeklyData, setWeeklyData] = useState<any>({ afreeca: [], twitch: [] });
+
+  useEffect(() => {
+    const timeoutID = window.setTimeout(() => {
+      setWeeklyData(dummyWeeklyData);
+    }, 2000);
+
+    return () => window.clearTimeout(timeoutID);
+  }, []);
 
   return (
     <div>
@@ -71,10 +98,8 @@ export default function Ranking(): JSX.Element {
               <section className={wrapper.monthlyScore}>
                 월간 점수
               </section>
-              <section className={wrapper.weeklyViewer}>
-                주간 시청자수 추이
-              </section>
-              <UserReaction />
+              <WeeklyViewerRankingCard data={weeklyData} />
+              <UserReactionCard />
             </Grid>
           </Grid>
         </Grid>

--- a/client/web/src/pages/mainpage/Ranking.tsx
+++ b/client/web/src/pages/mainpage/Ranking.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { Container, Grid } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+// import useAxios from 'axios-hooks';
 import Appbar from '../../organisms/shared/Appbar';
 import Footer from '../../organisms/shared/footer/Footer';
 import ProductHero from '../../organisms/mainpage/shared/ProductHero';
@@ -39,6 +40,7 @@ const useRankingPageLayout = makeStyles((theme: Theme) => createStyles({
 
 }));
 
+// 임시데이터 - 백엔드와 연결이후 삭제예정
 const dummyWeeklyData = {
   afreeca: [
     { date: '2021-3-5', totalViewer: 134321 },
@@ -64,14 +66,27 @@ export default function Ranking(): JSX.Element {
   const wrapper = useRankingPageLayout();
   const memoAppbar = useMemo(() => <Appbar />, []);
   const memoFooter = useMemo(() => <Footer />, []);
+
+  // const [{ loading: WeeklyDataLoading }, getWeeklyData] = useAxios({ url: '/rankings/weekly-viewers' }, { manual: true });
+  // 백엔드와 연결이후 바로 윗줄 코드와 교체예정
   const [weeklyData, setWeeklyData] = useState<any>({ afreeca: [], twitch: [] });
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const timeoutID = window.setTimeout(() => {
       setWeeklyData(dummyWeeklyData);
-    }, 2000);
+      setLoading(false);
+    }, 3000);
 
     return () => window.clearTimeout(timeoutID);
+
+    // 백엔드 코드 수정후 합칠 예정
+    // getWeeklyData().then((res) => {
+    //   setWeeklyData(res.data);
+    // }).catch((error) => {
+    //   // 에러핸들링
+    //   console.error(error);
+    // });
   }, []);
 
   return (
@@ -98,7 +113,11 @@ export default function Ranking(): JSX.Element {
               <section className={wrapper.monthlyScore}>
                 월간 점수
               </section>
-              <WeeklyViewerRankingCard data={weeklyData} />
+              <WeeklyViewerRankingCard
+                data={weeklyData}
+                loading={loading}
+                // loading={WeeklyDatLoading}
+              />
               <UserReactionCard />
             </Grid>
           </Grid>

--- a/client/web/src/pages/mainpage/Ranking.tsx
+++ b/client/web/src/pages/mainpage/Ranking.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { Container, Grid } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-// import useAxios from 'axios-hooks';
 import Appbar from '../../organisms/shared/Appbar';
 import Footer from '../../organisms/shared/footer/Footer';
 import ProductHero from '../../organisms/mainpage/shared/ProductHero';
@@ -40,54 +39,10 @@ const useRankingPageLayout = makeStyles((theme: Theme) => createStyles({
 
 }));
 
-// 임시데이터 - 백엔드와 연결이후 삭제예정
-const dummyWeeklyData = {
-  afreeca: [
-    { date: '2021-3-5', totalViewer: 134321 },
-    { date: '2021-3-4', totalViewer: 123411 },
-    { date: '2021-3-3', totalViewer: 134531 },
-    { date: '2021-3-2', totalViewer: 121351 },
-    { date: '2021-3-1', totalViewer: 123451 },
-    { date: '2021-2-28', totalViewer: 126421 },
-    { date: '2021-2-27', totalViewer: 134561 },
-  ],
-  twitch: [
-    { date: '2021-3-5', totalViewer: 109382 },
-    { date: '2021-3-4', totalViewer: 113452 },
-    { date: '2021-3-3', totalViewer: 124532 },
-    { date: '2021-3-2', totalViewer: 111352 },
-    { date: '2021-3-1', totalViewer: 113452 },
-    { date: '2021-2-28', totalViewer: 116422 },
-    { date: '2021-2-27', totalViewer: 124562 },
-  ],
-};
-
 export default function Ranking(): JSX.Element {
   const wrapper = useRankingPageLayout();
   const memoAppbar = useMemo(() => <Appbar />, []);
   const memoFooter = useMemo(() => <Footer />, []);
-
-  // const [{ loading: WeeklyDataLoading }, getWeeklyData] = useAxios({ url: '/rankings/weekly-viewers' }, { manual: true });
-  // 백엔드와 연결이후 바로 윗줄 코드와 교체예정
-  const [weeklyData, setWeeklyData] = useState<any>({ afreeca: [], twitch: [] });
-  const [loading, setLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    const timeoutID = window.setTimeout(() => {
-      setWeeklyData(dummyWeeklyData);
-      setLoading(false);
-    }, 3000);
-
-    return () => window.clearTimeout(timeoutID);
-
-    // 백엔드 코드 수정후 합칠 예정
-    // getWeeklyData().then((res) => {
-    //   setWeeklyData(res.data);
-    // }).catch((error) => {
-    //   // 에러핸들링
-    //   console.error(error);
-    // });
-  }, []);
 
   return (
     <div>
@@ -113,11 +68,7 @@ export default function Ranking(): JSX.Element {
               <section className={wrapper.monthlyScore}>
                 월간 점수
               </section>
-              <WeeklyViewerRankingCard
-                data={weeklyData}
-                loading={loading}
-                // loading={WeeklyDatLoading}
-              />
+              <WeeklyViewerRankingCard />
               <UserReactionCard />
             </Grid>
           </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,18 +2304,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react@*", "@types/react@^16", "@types/react@^16.9.49", "@types/react@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16", "@types/react@^16.9.49":
-  version "16.14.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
-  integrity sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -8096,6 +8088,16 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+highcharts-react-official@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/highcharts-react-official/-/highcharts-react-official-3.0.0.tgz#f2e81ed59d299c3473a0dd5ba5df24028875226a"
+  integrity sha512-VefJgDY2hkT9gfppsQGrRF2g5u8d9dtfHGcx2/xqiP+PkZXCqalw9xOeKVCRvJKTOh0coiDFwvVjOvB7KaGl4A==
+
+highcharts@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.0.1.tgz#49ec994a7897a96fc3e0880f49a0eca34adff6a2"
+  integrity sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==
 
 highlight.js@^10.0.0:
   version "10.5.0"


### PR DESCRIPTION
/rankings/weekly-viewers로 요청하여 받아온 
지난 30일간의 방송에 대한 웃음 점수, 감탄 점수, 답답함 점수 상위 5인을 표시하는 막대그래프

월간 평균 막대그래프 3개 포함하는 MonthlyScoresRankingCard 컴포넌트 생성
막대그래프 개별 컴포넌트 ScoresBarChart 컴포넌트 생성

- 1, 2, 3위 에게 금/은/동 표시
- 각 크리에이터 이름이 x축
- y축의 경우 상위 5인 중 최저점수부터 표시함(0부터 표시하지 않음) 
=> 점수차를 시각적으로 더 크게 보여주기 위해서