### PR TITLE
Update: 탑텐 목록 로딩 기존에 있던 데이터 까지 깜빡이지 않도록 수정

### DIFF
--- a/client/web/src/organisms/mainpage/ranking/topten/TopTenListContainer.tsx
+++ b/client/web/src/organisms/mainpage/ranking/topten/TopTenListContainer.tsx
@@ -63,24 +63,23 @@ function TopTenListContainer(props: TopTenListProps): JSX.Element {
 
       {/* 목록 아이템 컨테이너 */}
       <div className={classes.listItems} ref={containerRef}>
-        { (loading || !data)
-          ? (
-            Array.from(Array(10).keys())).map((v: number) => (
-              <ListItemSkeleton key={v} headerColumns={headerColumns} />
-          )) : data.rankingData.map((d, index: number) => {
-            const currentScoreName = currentTab === 'viewer' ? currentTab : `${currentTab}Score` as keyof Scores;
-            const weeklyTrendsData = data.weeklyTrends[d.creatorId];
-            return (
-              <TopTenListItem
-                key={d.id}
-                index={index}
-                data={d}
-                headerColumns={headerColumns}
-                currentScoreName={currentScoreName}
-                weeklyTrendsData={weeklyTrendsData}
-              />
-            );
-          })}
+        {data && data.rankingData.map((d, index: number) => {
+          const currentScoreName = currentTab === 'viewer' ? currentTab : `${currentTab}Score` as keyof Scores;
+          const weeklyTrendsData = data.weeklyTrends[d.creatorId];
+          return (
+            <TopTenListItem
+              key={d.id}
+              index={index}
+              data={d}
+              headerColumns={headerColumns}
+              currentScoreName={currentScoreName}
+              weeklyTrendsData={weeklyTrendsData}
+            />
+          );
+        })}
+        {loading && (Array.from(Array(10).keys())).map((v: number) => (
+          <ListItemSkeleton key={v} headerColumns={headerColumns} />
+        ))}
         {!loading && data
         && data.rankingData.length === 0
         && <Typography className={classes.informationText}>데이터가 없습니다.</Typography>}


### PR DESCRIPTION
탑텐 목록에 더보기 로딩시 목록전체가 로딩 스켈레톤으로 변경되더라구요
깜빡이는것보다 기존데이터는 남아있고
새로 들어온데이터가 붙여지는 방식이 더 깔끔한 것 같아 수정해봤습니다