### PR TITLE
 Add: 주간 집계 시청자 평점 순위 목록의 이름을 클릭 했을 때에도 크리에이터 상세페이지로 이동 추가

### DIFF
--- a/client/web/src/organisms/mainpage/ranking/style/RatingList.style.ts
+++ b/client/web/src/organisms/mainpage/ranking/style/RatingList.style.ts
@@ -22,11 +22,12 @@ export const useRatingsListItemStyles = makeStyles((theme: Theme) => {
       marginRight: theme.spacing(1),
       fontSize: theme.typography.body1.fontSize,
       fontWeight: theme.typography.fontWeightBold,
-      color: theme.palette.common.black,
+      color: theme.palette.text.primary,
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
     },
+    black: { color: contrastColor },
     ratingText: {
       textAlign: 'center',
       fontSize: theme.typography.body1.fontSize,

--- a/client/web/src/organisms/mainpage/ranking/style/RatingList.style.ts
+++ b/client/web/src/organisms/mainpage/ranking/style/RatingList.style.ts
@@ -22,6 +22,10 @@ export const useRatingsListItemStyles = makeStyles((theme: Theme) => {
       marginRight: theme.spacing(1),
       fontSize: theme.typography.body1.fontSize,
       fontWeight: theme.typography.fontWeightBold,
+      color: theme.palette.common.black,
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
     },
     ratingText: {
       textAlign: 'center',

--- a/client/web/src/organisms/mainpage/ranking/sub/RatingsListItem.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/RatingsListItem.tsx
@@ -1,7 +1,8 @@
 import {
-  ListItem, ListItemAvatar, Avatar, ListItemText, Typography, Grid,
+  ListItem, ListItemAvatar, Avatar, ListItemText, Typography, Grid, Link,
 } from '@material-ui/core';
 import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { ListItemOrderByRatings } from '@truepoint/shared/dist/res/CreatorRatingResType.interface';
 import Rating from '@material-ui/lab/Rating';
 import classnames from 'classnames';
@@ -14,6 +15,7 @@ export interface RatingsListItemProps extends ListItemOrderByRatings{
 export default function RatingsListItem(props: RatingsListItemProps): JSX.Element {
   const {
     averageRating, nickname, logo, order,
+    creatorId, platform,
   } = props;
   const classes = useRatingsListItemStyles();
   return (
@@ -27,12 +29,11 @@ export default function RatingsListItem(props: RatingsListItemProps): JSX.Elemen
             <Avatar className={classes.avatarImage} alt={`${nickname} 프로필 이미지`} src={logo} />
           </ListItemAvatar>
           <ListItemText primary={(
-            <Typography
-              component="span"
-              className={classes.creatorName}
-            >
-              {nickname}
-            </Typography>
+            <Link component={RouterLink} to={`/ranking/${platform}/${creatorId}`}>
+              <Typography className={classes.creatorName}>
+                {nickname}
+              </Typography>
+            </Link>
         )}
           />
         </Grid>

--- a/client/web/src/organisms/mainpage/ranking/sub/RatingsListItem.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/RatingsListItem.tsx
@@ -30,10 +30,10 @@ export default function RatingsListItem(props: RatingsListItemProps): JSX.Elemen
           </ListItemAvatar>
           <ListItemText primary={(
             <Link component={RouterLink} to={`/ranking/${platform}/${creatorId}`}>
-              <Typography className={classnames({
-                [classes.creatorName]: true,
-                [classes.black]: order && order < 5,
-              })}
+              <Typography
+                className={classnames(
+                  classes.creatorName, { [classes.black]: order && order < 5 },
+                )}
               >
                 {nickname}
               </Typography>

--- a/client/web/src/organisms/mainpage/ranking/sub/RatingsListItem.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/RatingsListItem.tsx
@@ -30,7 +30,11 @@ export default function RatingsListItem(props: RatingsListItemProps): JSX.Elemen
           </ListItemAvatar>
           <ListItemText primary={(
             <Link component={RouterLink} to={`/ranking/${platform}/${creatorId}`}>
-              <Typography className={classes.creatorName}>
+              <Typography className={classnames({
+                [classes.creatorName]: true,
+                [classes.black]: order && order < 5,
+              })}
+              >
                 {nickname}
               </Typography>
             </Link>

--- a/client/web/src/organisms/mainpage/ranking/topten/TopTenListContainer.tsx
+++ b/client/web/src/organisms/mainpage/ranking/topten/TopTenListContainer.tsx
@@ -63,24 +63,23 @@ function TopTenListContainer(props: TopTenListProps): JSX.Element {
 
       {/* 목록 아이템 컨테이너 */}
       <div className={classes.listItems} ref={containerRef}>
-        { (loading || !data)
-          ? (
-            Array.from(Array(10).keys())).map((v: number) => (
-              <ListItemSkeleton key={v} headerColumns={headerColumns} />
-          )) : data.rankingData.map((d, index: number) => {
-            const currentScoreName = currentTab === 'viewer' ? currentTab : `${currentTab}Score` as keyof Scores;
-            const weeklyTrendsData = data.weeklyTrends[d.creatorId];
-            return (
-              <TopTenListItem
-                key={d.id}
-                index={index}
-                data={d}
-                headerColumns={headerColumns}
-                currentScoreName={currentScoreName}
-                weeklyTrendsData={weeklyTrendsData}
-              />
-            );
-          })}
+        {data && data.rankingData.map((d, index: number) => {
+          const currentScoreName = currentTab === 'viewer' ? currentTab : `${currentTab}Score` as keyof Scores;
+          const weeklyTrendsData = data.weeklyTrends[d.creatorId];
+          return (
+            <TopTenListItem
+              key={d.id}
+              index={index}
+              data={d}
+              headerColumns={headerColumns}
+              currentScoreName={currentScoreName}
+              weeklyTrendsData={weeklyTrendsData}
+            />
+          );
+        })}
+        {loading && (Array.from(Array(10).keys())).map((v: number) => (
+          <ListItemSkeleton key={v} headerColumns={headerColumns} />
+        ))}
         {!loading && data
         && data.rankingData.length === 0
         && <Typography className={classes.informationText}>데이터가 없습니다.</Typography>}


### PR DESCRIPTION
탑텐 목록과 똑같이 이름을 클릭했을 때 상세 페이지로 이동하도록 추가했습니다.