### PR TITLE
auth controller 모든 가드 주석처리

### DIFF
--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -7,16 +7,17 @@ import {
   InternalServerErrorException, Post, Query,
   Req, Request,
   Res,
-  UseFilters, UseGuards,
+  UseFilters,
+  // UseGuards,
 } from '@nestjs/common';
 import { CheckCertificationDto } from '@truepoint/shared/dist/dto/auth/checkCertification.dto';
 import { LogoutDto } from '@truepoint/shared/dist/dto/auth/logout.dto';
 import express from 'express';
-import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
 // 가드 임시 주석처리
-import { LocalAuthGuard } from '../../guards/local-auth.guard';
-import { TwitchLinkGuard } from '../../guards/twitch-link.guard';
-import { YoutubeLinkGuard } from '../../guards/youtube-link.guard';
+// import { JwtAuthGuard } from '../../guards/jwt-auth.guard';
+// import { LocalAuthGuard } from '../../guards/local-auth.guard';
+// import { TwitchLinkGuard } from '../../guards/twitch-link.guard';
+// import { YoutubeLinkGuard } from '../../guards/youtube-link.guard';
 import { CertificationInfo } from '../../interfaces/certification.interface';
 import {
   LogedInExpressRequest, UserLoginPayload,
@@ -52,7 +53,7 @@ export class AuthController {
   }
 
   // 로그인 컨트롤러
-  @UseGuards(LocalAuthGuard)
+  // @UseGuards(LocalAuthGuard)
   @Post('login')
   async login(
     @Body('stayLogedIn') stayLogedIn: boolean,
@@ -83,7 +84,7 @@ export class AuthController {
    * @param req 로그인 user 정보를 포함한 요청 객체
    * @param password 패스워드 plain 문자열
    */
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @Post('check-pw')
   async checkPw(
     @Req() req: LogedInExpressRequest,
@@ -136,7 +137,7 @@ export class AuthController {
    * @param id 연동하는 플랫폼의 고유 아이디
    */
   @Post('link')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   async platformLink(
     @Req() req: LogedInExpressRequest,
     @Body('platform') platform: string, @Body('id') id: string,
@@ -153,7 +154,7 @@ export class AuthController {
    * @param platform 연동 제거할 플랫폼 문자열 twitch|youtube|afreeca 셋 중 하나.
    */
   @Delete('link')
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   async deletePlatformLink(
     @Req() req: LogedInExpressRequest, @Body('platform') platform: string,
   ): Promise<string> {
@@ -169,14 +170,14 @@ export class AuthController {
   // *********** Twitch ******************
   // Twitch Link start
   @Get('twitch')
-  @UseGuards(TwitchLinkGuard)
+  // @UseGuards(TwitchLinkGuard)
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   twitch(): void {}
 
   // Twitch oauth Callback url
   @Get('twitch/callback')
   @UseFilters(TwitchLinkExceptionFilter)
-  @UseGuards(TwitchLinkGuard)
+  // @UseGuards(TwitchLinkGuard)
   twitchCallback(
     @Req() req: express.Request,
     @Res() res: express.Response,
@@ -190,7 +191,7 @@ export class AuthController {
   // *********** Youtube ******************
   // Youtube link start
   @Get('youtube')
-  @UseGuards(YoutubeLinkGuard)
+  // @UseGuards(YoutubeLinkGuard)
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   youtube(): void {}
 


### PR DESCRIPTION
컨트롤러별 가드 사용 여부 파악 후 모든 컨트롤러에서 가드 주석처리함

**가드를 사용하고 있던 컨트롤러**
- auth.controller → 다른부분은 다 주석처리 되어있었고, 이 컨트롤러만 주석 해제되어 있었음
- broadcast-info.controller
- category.controller
- notification.controller
- stream-analysis.controller
- users.controller

