### PR TITLE
회원가입, 로그인 기능 관련 비일관적 코드 수정

### DIFF
--- a/client/web/src/index.tsx
+++ b/client/web/src/index.tsx
@@ -18,13 +18,14 @@ import defaultTheme from './theme';
 import Main from './pages/mainpage/Main';
 import PrivacyPolicy from './pages/others/PrivacyPolicy';
 import TermsOfUse from './pages/others/TermsOfUse';
-import Mypage from './pages/mypage/layouts/MypageLayout';
 import PublickMypage from './pages/mainpage/PublicMypage';
 import KakaoTalk from './organisms/shared/KakaoTalkButton';
-import Login from './pages/mainpage/Login';
-import Regist from './pages/mainpage/Regist';
-import FindId from './pages/others/FindId';
-import FindPassword from './pages/others/FindPassword';
+// ** 트루포인트 2.5기준 로그인&회원가입 기능이 없으므로 페이지 주석처리 **
+// import Mypage from './pages/mypage/layouts/MypageLayout';
+// import Login from './pages/mainpage/Login';
+// import Regist from './pages/mainpage/Regist';
+// import FindId from './pages/others/FindId';
+// import FindPassword from './pages/others/FindPassword';
 import FeatureSuggestion from './pages/mainpage/FeatureSuggestion';
 import FeatureSuggestionWrite from './pages/mainpage/FeatureSuggestionWrite';
 import CommunityBoard from './pages/mainpage/CommunityBoard';
@@ -34,7 +35,7 @@ import useTruepointThemeType from './utils/hooks/useTruepointThemeType';
 import AuthContext, { useLogin } from './utils/contexts/AuthContext';
 import { TruepointTheme } from './interfaces/TruepointTheme';
 import Notice from './pages/mainpage/Notice';
-// 트루포인트 2.5 로그인 기능 추가 전이라 주석처리
+// ** 트루포인트 2.5기준 로그인&회원가입 기능이 없으므로 페이지 주석처리 **
 // import useAutoLogin from './utils/hooks/useAutoLogin';
 // import SubscribeContext, { useSubscribe } from './utils/contexts/SubscribeContext';
 
@@ -113,11 +114,12 @@ function Index(): JSX.Element {
             <Switch>
               <Route exact path="/" component={Ranking} />
               <Route exact path="/about-us" component={Main} />
-              <Route exact path="/signup" component={Regist} />
-              <Route exact path="/signup/completed" component={Regist} />
-              <Route exact path="/login" component={Login} />
-              <Route exact path="/find-id" component={FindId} />
-              <Route exact path="/find-pw" component={FindPassword} />
+              {/** 트루포인트 2.5기준 로그인&회원가입 기능이 없으므로 페이지 주석처리 * */}
+              {/* <Route exact path="/signup" component={Regist} /> */}
+              {/* <Route exact path="/signup/completed" component={Regist} /> */}
+              {/* <Route exact path="/login" component={Login} /> */}
+              {/* <Route exact path="/find-id" component={FindId} /> */}
+              {/* <Route exact path="/find-pw" component={FindPassword} /> */}
               <Route exact path="/notice" component={Notice} />
               <Route exact path="/notice/:id" component={Notice} />
               <Route exact path="/feature-suggestion" component={FeatureSuggestion} />
@@ -130,7 +132,8 @@ function Index(): JSX.Element {
               <Route path="/ranking" component={Ranking} />
               <Route exact path="/highlight-list" component={YoutubeHighlightList} />
               <Route path="/public-mypage/:type/:userId" component={PublickMypage} />
-              <Route path="/mypage" component={Mypage} />
+              {/* 트루포인트 2.5기준 로그인&회원가입 기능이 없으므로 페이지 주석처리 */}
+              {/* <Route path="/mypage" component={Mypage} /> */}
               <Route component={PageNotFound} />
             </Switch>
             {/* 페이지 컴포넌트 */}

--- a/client/web/src/organisms/mypage/dashboard/UserMetricsSection.tsx
+++ b/client/web/src/organisms/mypage/dashboard/UserMetricsSection.tsx
@@ -15,6 +15,7 @@ import ProgressBar from '../../../atoms/Progressbar/ProgressBar';
 import RedProgressBar from '../../../atoms/Progressbar/RedProgressBar';
 import UserMetricsChart from './sub/UserMetricsChart';
 import useAuthContext from '../../../utils/hooks/useAuthContext';
+import { usePublicMypageContext } from '../../../utils/contexts/PublicMyPageContext';
 
 const useStyles = makeStyles((theme) => ({
   chartContainer: { padding: theme.spacing(4), height: 575, overflow: 'hidden' },
@@ -60,6 +61,7 @@ export interface DataCard {
 
 export default function UserMetricsSection(): JSX.Element {
   const auth = useAuthContext();
+  const selectedCreator = usePublicMypageContext();
   const PLATFORM_LIST = ['afreeca', 'twitch', 'youtube'];
   const classes = useStyles();
 
@@ -68,7 +70,7 @@ export default function UserMetricsSection(): JSX.Element {
   const [{ loading, data }, refetch] = useAxios<UserMetrics[]>({
     url: 'stream-analysis/user-statistics',
     method: 'GET',
-    params: { userId: auth.user.userId },
+    params: { userId: auth.user.userId || selectedCreator.userId },
   });
   useEffect(() => {
     refetch();

--- a/client/web/src/organisms/mypage/dashboard/UserProfile.tsx
+++ b/client/web/src/organisms/mypage/dashboard/UserProfile.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
-import classnames from 'classnames';
 import {
-  Avatar, Chip, CircularProgress, Paper, Typography,
+  Avatar, CircularProgress, Paper, Typography,
 } from '@material-ui/core';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { User } from '@truepoint/shared/dist/interfaces/User.interface';
@@ -11,6 +10,7 @@ import useAxios from 'axios-hooks';
 import useDialog from '../../../utils/hooks/useDialog';
 import MainDialog from './MainDialog';
 import useAuthContext from '../../../utils/hooks/useAuthContext';
+import { usePublicMypageContext } from '../../../utils/contexts/PublicMyPageContext';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -30,8 +30,9 @@ const useStyles = makeStyles((theme) => ({
 export default function UserProfile(): JSX.Element {
   const classes = useStyles();
   const auth = useAuthContext();
+  const selectedCreator = usePublicMypageContext();
   const [profileRequestObject, refetch] = useAxios<User>({
-    url: 'users', method: 'GET', params: { userId: auth.user.userId },
+    url: 'users', method: 'GET', params: { userId: auth.user.userId || selectedCreator.userId },
   });
 
   const { open, handleOpen, handleClose } = useDialog();
@@ -93,7 +94,7 @@ export default function UserProfile(): JSX.Element {
             )}
 
             {/* 요금제 */}
-            {/* <div className={classnames(classes.flexBox, classes.secondSection)}>
+            {/* <div className={(classes.flexBox, classes.secondSection)}>
               <Typography className={classes.bold} variant="body1">요금제</Typography>
               <Chip label="클로즈베타 테스터" size="small" color="primary" className={classes.userTier} />
             </div> */}

--- a/client/web/src/organisms/mypage/dashboard/UserProfile.tsx
+++ b/client/web/src/organisms/mypage/dashboard/UserProfile.tsx
@@ -93,10 +93,10 @@ export default function UserProfile(): JSX.Element {
             )}
 
             {/* 요금제 */}
-            <div className={classnames(classes.flexBox, classes.secondSection)}>
+            {/* <div className={classnames(classes.flexBox, classes.secondSection)}>
               <Typography className={classes.bold} variant="body1">요금제</Typography>
               <Chip label="클로즈베타 테스터" size="small" color="primary" className={classes.userTier} />
-            </div>
+            </div> */}
 
             {/* 클로즈베타 처리 - 잠시 제거 */}
             {/* <Typography className={classes.text} variant="body1" color="primary" paragraph>

--- a/client/web/src/organisms/mypage/highlightAnalysis/Calendar.tsx
+++ b/client/web/src/organisms/mypage/highlightAnalysis/Calendar.tsx
@@ -23,6 +23,7 @@ import ShowSnack from '../../../atoms/snackbar/ShowSnack';
 import SelectDateIcon from '../../../atoms/stream-analysis-icons/SelectDateIcon';
 // hooks
 import useAuthContext from '../../../utils/hooks/useAuthContext';
+import { usePublicMypageContext } from '../../../utils/contexts/PublicMyPageContext';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -105,6 +106,7 @@ function StreamCalendar(props: StreamCalenderProps): JSX.Element {
   const [currMonth, setCurrMonth] = React.useState<MaterialUiPickersDate>(new Date());
   const [hasStreamDays, setHasStreamDays] = React.useState<string[]>([]);
   const auth = useAuthContext();
+  const selectedCreator = usePublicMypageContext();
 
   const reRequest = 3;
   const [
@@ -130,7 +132,7 @@ function StreamCalendar(props: StreamCalenderProps): JSX.Element {
 
   React.useEffect(() => {
     const params: SearchCalendarStreams = {
-      userId: exampleMode ? 'sal_gu' : auth.user.userId,
+      userId: exampleMode ? 'sal_gu' : auth.user.userId || selectedCreator.userId,
       startDate: handleSubtractCurrMonth(currMonth)[0],
       endDate: handleSubtractCurrMonth(currMonth)[1],
     };
@@ -146,7 +148,7 @@ function StreamCalendar(props: StreamCalenderProps): JSX.Element {
         ShowSnack('달력 정보구성에 문제가 발생했습니다.', 'error', enqueueSnackbar);
       }
     });
-  }, [exampleMode, auth.user.userId, currMonth, excuteGetStreams, enqueueSnackbar]);
+  }, [exampleMode, auth.user.userId, currMonth, excuteGetStreams, enqueueSnackbar, selectedCreator.userId]);
 
   const handleDayChange = (newDate: MaterialUiPickersDate) => {
     if (newDate) handleClickedDate(newDate);

--- a/client/web/src/organisms/mypage/stream-analysis/period-analysis/PeriodAnalysisSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/period-analysis/PeriodAnalysisSection.tsx
@@ -37,6 +37,7 @@ import CheckBoxGroup from '../shared/CheckBoxGroup';
 import SectionTitle from '../../../shared/sub/SectionTitles';
 import ShowSnack from '../../../../atoms/snackbar/ShowSnack';
 import PeriodSelectDialog from '../shared/PeriodSelectDialog';
+import { usePublicMypageContext } from '../../../../utils/contexts/PublicMyPageContext';
 
 export default function PeriodAnalysisSection(props: PeriodAnalysisProps): JSX.Element {
   const {
@@ -54,6 +55,7 @@ export default function PeriodAnalysisSection(props: PeriodAnalysisProps): JSX.E
 
   // const subscribe = React.useContext(SubscribeContext);
   const auth = useAuthContext(); // 유저 컨텍스트
+  const selectedCreator = usePublicMypageContext();
   const { enqueueSnackbar } = useSnackbar(); // 스낵바 컨텍스트 호출
   const { open, handleClose, handleOpen } = useDialog(); // 다이얼로그 훅
 
@@ -104,10 +106,11 @@ export default function PeriodAnalysisSection(props: PeriodAnalysisProps): JSX.E
   React.useEffect(() => {
     if (period[0] && period[1]) {
       const searchParam: SearchCalendarStreams = {
-        userId: exampleMode ? 'sal_gu' : auth.user.userId,
+        userId: exampleMode ? 'sal_gu' : (auth.user.userId || selectedCreator.userId),
         startDate: period[0].toISOString(),
         endDate: period[1].toISOString(),
       };
+
       excuteGetStreams({
         params: searchParam,
       }).then((res) => {
@@ -121,7 +124,7 @@ export default function PeriodAnalysisSection(props: PeriodAnalysisProps): JSX.E
         }
       });
     }
-  }, [exampleMode, period, auth.user, excuteGetStreams, enqueueSnackbar]);
+  }, [exampleMode, period, excuteGetStreams, enqueueSnackbar, auth.user.userId, selectedCreator.userId]);
 
   /* 네비바 유저 전환시 이전 값 초기화 -> CBT 주석 사항 */
   // React.useEffect(() => {
@@ -132,7 +135,7 @@ export default function PeriodAnalysisSection(props: PeriodAnalysisProps): JSX.E
   //     smile: false,
   //   });
   //   setTermStreamsList([]);
-  // }, [auth.user]);
+  // },]);
 
   /**
    * 부모 요소로 부터 받은 방송 분석 요청 버튼 핸들러

--- a/client/web/src/organisms/mypage/stream-analysis/period-vs-period/PeriodCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/period-vs-period/PeriodCompareSection.tsx
@@ -33,6 +33,7 @@ import PeriodSelectDialog from '../shared/PeriodSelectDialog';
 import SectionTitle from '../../../shared/sub/SectionTitles';
 // attoms snackbar
 import ShowSnack from '../../../../atoms/snackbar/ShowSnack';
+import { usePublicMypageContext } from '../../../../utils/contexts/PublicMyPageContext';
 
 export default function PeriodCompareSection(props: PeriodCompareProps): JSX.Element {
   const {
@@ -50,6 +51,7 @@ export default function PeriodCompareSection(props: PeriodCompareProps): JSX.Ele
 
   const { enqueueSnackbar } = useSnackbar();
   const auth = useAuthContext();
+  const selectedCreator = usePublicMypageContext();
 
   /* 다이얼로그 */
   const baseDialog = useDialog();
@@ -178,7 +180,7 @@ export default function PeriodCompareSection(props: PeriodCompareProps): JSX.Ele
   React.useEffect(() => {
     if (basePeriod[0] && basePeriod[1]) {
       const searchParam: SearchCalendarStreams = {
-        userId: exampleMode ? 'sal_gu' : auth.user.userId,
+        userId: exampleMode ? 'sal_gu' : (auth.user.userId || selectedCreator.userId),
         startDate: basePeriod[0].toISOString(),
         endDate: basePeriod[1].toISOString(),
       };
@@ -197,7 +199,7 @@ export default function PeriodCompareSection(props: PeriodCompareProps): JSX.Ele
         }
       });
     }
-  }, [exampleMode, basePeriod, auth.user, excuteGetStreams, enqueueSnackbar]);
+  }, [exampleMode, basePeriod, auth.user, excuteGetStreams, enqueueSnackbar, selectedCreator.userId]);
 
   React.useEffect(() => {
     if (comparePeriod[0] && comparePeriod[1]) {

--- a/client/web/src/organisms/mypage/stream-analysis/shared/RangeSelectCalendar.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/shared/RangeSelectCalendar.tsx
@@ -33,6 +33,7 @@ import ShowSnack from '../../../../atoms/snackbar/ShowSnack';
 import useAllCalendarStyles from './RangeSelectCalendar.style';
 import StepGuideTooltip from '../../../../atoms/Tooltip/StepGuideTooltip';
 import { stepguideSource } from '../../../../atoms/Tooltip/StepGuideTooltip.text';
+import { usePublicMypageContext } from '../../../../utils/contexts/PublicMyPageContext';
 
 const reRequest = 3;
 function RangeSelectCaledar(props: RangeSelectCaledarProps): JSX.Element {
@@ -43,6 +44,7 @@ function RangeSelectCaledar(props: RangeSelectCaledarProps): JSX.Element {
   const classes = useAllCalendarStyles();
   // const subscribe = React.useContext(SubscribeContext);
   const auth = useAuthContext();
+  const selectedCreator = usePublicMypageContext();
   const { enqueueSnackbar } = useSnackbar();
   const theme = useTheme();
 
@@ -103,7 +105,7 @@ function RangeSelectCaledar(props: RangeSelectCaledarProps): JSX.Element {
 
   React.useEffect(() => {
     const params: SearchCalendarStreams = {
-      userId: exampleMode ? 'sal_gu' : auth.user.userId,
+      userId: exampleMode ? 'sal_gu' : (auth.user.userId || selectedCreator.userId),
       startDate: handleSubtractCurrMonth(currMonth)[0],
       endDate: handleSubtractCurrMonth(currMonth)[1],
     };
@@ -119,7 +121,7 @@ function RangeSelectCaledar(props: RangeSelectCaledarProps): JSX.Element {
         ShowSnack('달력 정보 구성에 문제가 발생했습니다.', 'error', enqueueSnackbar);
       }
     });
-  }, [exampleMode, auth.user, excuteGetStreams, enqueueSnackbar, currMonth]);
+  }, [exampleMode, auth.user, excuteGetStreams, enqueueSnackbar, currMonth, selectedCreator.userId]);
 
   React.useEffect(() => {
     if (period.length > 1 && period[0] && period[1]) {

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/Calendar.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/Calendar.tsx
@@ -27,6 +27,7 @@ import { StreamCalendarProps } from './StreamCompareSectioninterface';
 import useAuthContext from '../../../../utils/hooks/useAuthContext';
 // attoms snackbar
 import ShowSnack from '../../../../atoms/snackbar/ShowSnack';
+import { usePublicMypageContext } from '../../../../utils/contexts/PublicMyPageContext';
 
 const useStyles = makeStyles((theme: Theme) => ({
   hasStreamDayDot: {
@@ -57,6 +58,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
   } = props;
   const classes = useStyles();
   const auth = useAuthContext();
+  const selectedCreator = usePublicMypageContext();
   const [hasStreamDays, setHasStreamDays] = React.useState<string[]>([]);
   const [currMonth, setCurrMonth] = React.useState<MaterialUiPickersDate>(new Date());
   const { enqueueSnackbar } = useSnackbar();
@@ -113,7 +115,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
    */
   React.useEffect(() => {
     const params: SearchCalendarStreams = {
-      userId: exampleMode ? 'sal_gu' : auth.user.userId,
+      userId: exampleMode ? 'sal_gu' : (auth.user.userId || selectedCreator.userId),
       startDate: handleSubtractCurrMonth(currMonth)[0],
       endDate: handleSubtractCurrMonth(currMonth)[1],
     };
@@ -129,7 +131,7 @@ function StreamCalendar(props: StreamCalendarProps): JSX.Element {
         ShowSnack('달력 정보구성에 문제가 발생했습니다.', 'error', enqueueSnackbar);
       }
     });
-  }, [exampleMode, auth.user.userId, currMonth, excuteGetStreams, enqueueSnackbar]);
+  }, [exampleMode, auth.user.userId, currMonth, excuteGetStreams, enqueueSnackbar, selectedCreator.userId]);
 
   /**
    * 달력 날짜 선택 핸들러

--- a/client/web/src/pages/mainpage/PublicMypage.tsx
+++ b/client/web/src/pages/mainpage/PublicMypage.tsx
@@ -11,6 +11,7 @@ import PageSizeAlert from '../../organisms/mypage/alertbar/PageSizeAlert';
 import SidebarWithNavbar from '../../organisms/mypage/layouts/sidebar-with-navbar/SidebarWithNavbar';
 import useAuthContext from '../../utils/hooks/useAuthContext';
 import useDialog from '../../utils/hooks/useDialog';
+import PublicMypageContext from '../../utils/contexts/PublicMyPageContext';
 
 export interface ParamTypes {
   userId: string
@@ -33,6 +34,7 @@ export default function PublicMypage(): JSX.Element {
     if (userId) {
       auth.user.userId = userId;
     }
+    setSelectedCreatorId(userId);
   }, [auth, userId]);
 
   // 사이드바 오픈 스테이트
@@ -44,10 +46,21 @@ export default function PublicMypage(): JSX.Element {
     setOpen(false);
   };
 
+  // publicMypageContextValue
+  const [selectedCreatorId, setSelectedCreatorId] = useState<string>('');
+  const changeUserId = (newUserId: string) => {
+    setSelectedCreatorId(newUserId);
+  };
+
   const memoAppbar = useMemo(() => (<AppBar />), []);
 
   return (
-    <>
+
+    <PublicMypageContext.Provider value={{
+      userId: selectedCreatorId,
+      changeUserId,
+    }}
+    >
       {/* 최상단 네비바 */}
       {memoAppbar}
 
@@ -57,7 +70,6 @@ export default function PublicMypage(): JSX.Element {
         handleOpen={handleAlertOpen}
         handleClose={handleAlertClose}
       />
-
       <div className={classes.wrapper}>
         {/* 마이페이지 상단 네비바 */}
         <SidebarWithNavbar
@@ -78,7 +90,7 @@ export default function PublicMypage(): JSX.Element {
                     route.subRoutes && route.subRoutes.map((subRoute) => (
                       <Route
                         path={`${subRoute.layout}${subRoute.path}`}
-                        component={subRoute.component}
+                        component={route.component}
                         key={subRoute.name}
                       />
                     ))
@@ -94,6 +106,6 @@ export default function PublicMypage(): JSX.Element {
           </div>
         </main>
       </div>
-    </>
+    </PublicMypageContext.Provider>
   );
 }

--- a/client/web/src/pages/mainpage/PublicMypage.tsx
+++ b/client/web/src/pages/mainpage/PublicMypage.tsx
@@ -9,7 +9,6 @@ import routes from '../../organisms/mainpage/youtubeHighlight/publicMypage/publi
 import AppBar from '../../organisms/shared/Appbar';
 import PageSizeAlert from '../../organisms/mypage/alertbar/PageSizeAlert';
 import SidebarWithNavbar from '../../organisms/mypage/layouts/sidebar-with-navbar/SidebarWithNavbar';
-import useAuthContext from '../../utils/hooks/useAuthContext';
 import useDialog from '../../utils/hooks/useDialog';
 import PublicMypageContext from '../../utils/contexts/PublicMyPageContext';
 
@@ -20,7 +19,6 @@ export interface ParamTypes {
 export default function PublicMypage(): JSX.Element {
   const classes = useLayoutStyles();
   const { userId } = useParams<ParamTypes>();
-  const auth = useAuthContext();
   const { open: alertOpen, handleOpen: handleAlertOpen, handleClose: handleAlertClose } = useDialog();
 
   // main ref
@@ -30,12 +28,8 @@ export default function PublicMypage(): JSX.Element {
       mainPanel.current.scrollTop = 0;
     }
 
-    // 비로그인 시 유저 정보 조회 용도
-    if (userId) {
-      auth.user.userId = userId;
-    }
     setSelectedCreatorId(userId);
-  }, [auth, userId]);
+  }, [userId]);
 
   // 사이드바 오픈 스테이트
   const [open, setOpen] = useState(true);
@@ -46,13 +40,15 @@ export default function PublicMypage(): JSX.Element {
     setOpen(false);
   };
 
-  // publicMypageContextValue
+  const memoAppbar = useMemo(() => (<AppBar />), []);
+
+  // PublicMypage에서 authContext.user(로그인한 유저) 값을 덮어쓰는 대신
+  // PublicMypageContext를 생성하여 userId를 공유하고자 함
+  // publicMypageContext의 contextValue
   const [selectedCreatorId, setSelectedCreatorId] = useState<string>('');
   const changeUserId = (newUserId: string) => {
     setSelectedCreatorId(newUserId);
   };
-
-  const memoAppbar = useMemo(() => (<AppBar />), []);
 
   return (
 
@@ -90,7 +86,7 @@ export default function PublicMypage(): JSX.Element {
                     route.subRoutes && route.subRoutes.map((subRoute) => (
                       <Route
                         path={`${subRoute.layout}${subRoute.path}`}
-                        component={route.component}
+                        component={subRoute.component}
                         key={subRoute.name}
                       />
                     ))

--- a/client/web/src/utils/contexts/PublicMyPageContext.tsx
+++ b/client/web/src/utils/contexts/PublicMyPageContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+export interface PublicMypageContextState{
+  userId: string;
+  changeUserId: (userId: string) => void,
+}
+
+const defaultState: PublicMypageContextState = {
+  userId: '',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  changeUserId: (userId: string) => {},
+};
+
+const PublicMypageContext = createContext<PublicMypageContextState>(defaultState);
+
+export default PublicMypageContext;
+
+export function usePublicMypageContext(): PublicMypageContextState {
+  return useContext(PublicMypageContext);
+}

--- a/server/src/resources/auth/auth.controller.ts
+++ b/server/src/resources/auth/auth.controller.ts
@@ -19,7 +19,8 @@ import { TwitchLinkGuard } from '../../guards/twitch-link.guard';
 import { YoutubeLinkGuard } from '../../guards/youtube-link.guard';
 import { CertificationInfo } from '../../interfaces/certification.interface';
 import {
-  LogedInExpressRequest, UserLoginPayload,
+  LogedInExpressRequest,
+  // UserLoginPayload,
 } from '../../interfaces/logedInUser.interface';
 import { ValidationPipe } from '../../pipes/validation.pipe';
 import getFrontHost from '../../utils/getFrontHost';
@@ -53,29 +54,31 @@ export class AuthController {
 
   // 로그인 컨트롤러
   @UseGuards(LocalAuthGuard)
-  @Post('login')
-  async login(
-    @Body('stayLogedIn') stayLogedIn: boolean,
-    @Request() req: express.Request,
-    @Res() res: express.Response,
-  ): Promise<void> {
-    const user = req.user as UserLoginPayload;
-    const {
-      accessToken, refreshToken,
-    } = await this.authService.login(user, stayLogedIn);
+  /** 트루포인트 2.5 로그인 기능 없어서 주석처리 */
+  // @Post('login')
+  // async login(
+  //   @Body('stayLogedIn') stayLogedIn: boolean,
+  //   @Request() req: express.Request,
+  //   @Res() res: express.Response,
+  // ): Promise<void> {
+  //   const user = req.user as 
+  // ;
+  //   const {
+  //     accessToken, refreshToken,
+  //   } = await this.authService.login(user, stayLogedIn);
 
-    // *************************************
-    // 연동된 플랫폼(아/트/유) 유저 정보 최신화 작업
+  //   // *************************************
+  //   // 연동된 플랫폼(아/트/유) 유저 정보 최신화 작업
 
-    // 아프리카의 경우 아직 Profile Data를 제공하지 않아 불가능. 2020.12.08 @by hwasurr
-    // if (user.afreecaId) this.usersService.refreshAfreecaInfo(user.afreecaId);
-    if (user.twitch.twitchId) this.usersService.refreshTwitchInfo(user.twitch.twitchId);
-    if (user.youtube.youtubeId) this.usersService.refreshYoutubeInfo(user.youtube.youtubeId);
+  //   // 아프리카의 경우 아직 Profile Data를 제공하지 않아 불가능. 2020.12.08 @by hwasurr
+  //   // if (user.afreecaId) this.usersService.refreshAfreecaInfo(user.afreecaId);
+  //   if (user.twitch.twitchId) this.usersService.refreshTwitchInfo(user.twitch.twitchId);
+  //   if (user.youtube.youtubeId) this.usersService.refreshYoutubeInfo(user.youtube.youtubeId);
 
-    // Set-Cookie 헤더로 refresh_token을 담은 HTTP Only 쿠키를 클라이언트에 심는다.
-    res.cookie('refresh_token', refreshToken, { httpOnly: true });
-    res.send({ access_token: accessToken });
-  }
+  //   // Set-Cookie 헤더로 refresh_token을 담은 HTTP Only 쿠키를 클라이언트에 심는다.
+  //   res.cookie('refresh_token', refreshToken, { httpOnly: true });
+  //   res.send({ access_token: accessToken });
+  // }
 
   /**
    * 패스워드가 맞는지 확인하여 true , false를 반환하는 컨트롤러로,


### PR DESCRIPTION
- 로그인, 회원가입 관련 기능 주석처리(로그인, 회원가입 기능 없음에도 /login으로 접속시 로그인 페이지가 보임)
        - 로그인 페이지 주석처리
        - 회원가입 페이지 주석처리
        - 마이페이지 주석처리
        - 유투브편집점 > 대시보드에서 '요금제 - 클로즈베타테스터' 부분 숨기기
        - 로그인 라우터 주석처리

- authContext 값을 임의로 설정하여 로그인한 것과 비슷한 환경을 만들어 userId 값을 가져오는 방식 수정
    - PublicMypage를 감싸는 publicMypageContext 생성하여 userId 저장
    - PublicMypage 내에서 authContext.user.userId 가져오는 부분에서 authContext.user.userId 가 없는 경우 publicMypageContext.userId 사용하도록 함

```tsx
// 예시
    const auth = useAuthContext(); // 유저 컨텍스트
    const selectedCreator = usePublicMypageContext(); //publicMypageContext

    // 로그인하여 auth.user 값이 존재하는 경우 auth.user.userId(로그인한 유저) 값 사용
    // 로그인하지 않아서 auth.user값이 없는 경우 
    //   selectedCreator.userId (publicMypage에서 params로 받아온 방송인 id) 사용
    const searchParam: SearchCalendarStreams = {
            userId: exampleMode ? 'sal_gu' : (auth.user.userId || selectedCreator.userId)
          };
```