### PR TITLE
[Codestyle] prettier 룰을 더 많이 적용하는 방식으로 코드스타일(eslintrc, prettierrc) 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,10 +20,10 @@ module.exports = {
     "react",
     "react-hooks",
     '@typescript-eslint/eslint-plugin',
-    'prettier',
     'jest'
   ],
   extends: [
+    "plugin:prettier/recommended",
     "plugin:react/recommended",
     'airbnb-base',
     'airbnb',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,14 +20,12 @@ module.exports = {
     "react",
     "react-hooks",
     '@typescript-eslint/eslint-plugin',
-    'jest'
+    'jest',
   ],
   extends: [
+    'airbnb',
     "plugin:prettier/recommended",
     "plugin:react/recommended",
-    'airbnb-base',
-    'airbnb',
-    'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
   ],
@@ -50,11 +48,11 @@ module.exports = {
     'comma-dangle': 2,
     'linebreak-style': 'off',
     'no-useless-constructor': 0,
-    'max-len': ["error", {
-      code: 120, tabWidth: 2, ignoreComments: true, ignoreTrailingComments: true, ignoreStrings: true,
-      ignoreUrls: true, ignoreTemplateLiterals: true,
-      ignorePattern: "^import\\s.+\\sfrom\\s.+;$",
-    }],
+    // 'max-len': ["error", {
+    //   code: 120, tabWidth: 2, ignoreComments: true, ignoreTrailingComments: true, ignoreStrings: true,
+    //   ignoreUrls: true, ignoreTemplateLiterals: true,
+    //   ignorePattern: "^import\\s.+\\sfrom\\s.+;$",
+    // }],
     'max-params': ["warn", 4],
     "no-shadow": 2,
     /**

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "printWidth": 100,
+    "tabWidth": 2,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "bracketSpacing": true,
+    "semi": true,
+    "useTabs": false,
+    "arrowParens": "avoid",
+    "endOfLine": "lf"
+  }


### PR DESCRIPTION
몇가지 상황에서 코드 스타일링이 느슨하게 적용되어 제각각으로 작성된 코드 존재
(import statement, line길이, callback chaining)

- prettier 에서 제어하는 eslint 룰을 disable
- prettier 에서 제어할 수 있는 것은 모두 제어하여, 코드스타일링이 조금 더 강제성을 띄도록 변경

일단 룰만 변경한 상태로 merge, 날잡아 한번에 모두 변경한 뒤 적용 필요
(코드스타일 모든 변경사항 적용 이후, 적용된 dev 를 내려받아 일을 진행해야 충돌없이 진행할 수 있다)