### PR TITLE
tp production DB의 Streams 테이블에서 userId컬럼이 누락되어, 데이터가 있음에도 편집점 분석 달력에 표시되지 않는 문제 수정

### DIFF
--- a/client/web/src/organisms/mainpage/youtubeHighlight/list/PostList.tsx
+++ b/client/web/src/organisms/mainpage/youtubeHighlight/list/PostList.tsx
@@ -143,9 +143,13 @@ function PostList(props: PostListProps): JSX.Element {
           component={Link}
           to={`/public-mypage/main/${rowData.userId}`}
         >
-          <Typography variant="subtitle1" align="center" className={classes.columnText}>
+          {/* 서버에서 받아오는 title이 가장 최근 방송 제목을 반영하지 않고 있음 */}
+          {/* <Typography variant="subtitle1" align="center" className={classes.columnText}>
             {`${rowData.title.slice(0, 15)}`}
             {rowData.title.length > 15 ? '...' : null}
+          </Typography> */}
+          <Typography variant="subtitle1" align="center" className={classes.columnText}>
+            편집점 확인
           </Typography>
         </Button>
       ),

--- a/server/src/resources/broadcast-info/broadcast-info.module.ts
+++ b/server/src/resources/broadcast-info/broadcast-info.module.ts
@@ -15,7 +15,7 @@ import { PlatformTwitchEntity } from '../users/entities/platformTwitch.entity';
 import { UserEntity } from '../users/entities/user.entity';
 import { StreamCommentsEntity } from './entities/streamComment.entity';
 import { StreamCommentVoteEntity } from './entities/streamCommentVote.entity';
-
+import { UsersModule } from '../users/users.module';
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -24,6 +24,7 @@ import { StreamCommentVoteEntity } from './entities/streamCommentVote.entity';
       StreamCommentsEntity, StreamCommentVoteEntity,
     ]),
     TypeOrmConfigService,
+    UsersModule,
   ],
   controllers: [BroadcastInfoController, StreamCommentController],
   providers: [BroadcastInfoService, StreamCommentService, StreamCommentVoteService],

--- a/server/src/resources/stream-analysis/stream-analysis.service.ts
+++ b/server/src/resources/stream-analysis/stream-analysis.service.ts
@@ -21,6 +21,8 @@ import { EachStream } from '@truepoint/shared/dist/dto/stream-analysis/eachStrea
 import { StreamsInfo } from './interface/streamsInfo.interface';
 import { S3StreamData, OrganizedData } from './interface/S3StreamData.interface';
 // import { TimeLineData } from './interface/timeLineData.interface';
+
+import { UsersService } from '../users/users.service';
 // database entities
 import { StreamsEntity } from './entities/streams.entity';
 import { StreamSummaryEntity } from './entities/streamSummary.entity';
@@ -109,6 +111,7 @@ export class StreamAnalysisService {
       private readonly streamsRepository: Repository<StreamsEntity>,
     @InjectRepository(StreamSummaryEntity)
       private readonly streamSummaryRepository: Repository<StreamSummaryEntity>,
+      private readonly usersService: UsersService,
   ) {}
 
   /**
@@ -265,9 +268,13 @@ export class StreamAnalysisService {
       length    :  기간내 방송 당 방송 시간 평균 
       chatCount :  기간내 총 채팅 발생 수 -> 단순 합산
     */
+
+    const creatorIds = await this.usersService.findOneCreatorIds(userId);
+
     const streams = await this.streamsRepository
       .createQueryBuilder('streams')
-      .where('streams.userId = :id', { id: userId })
+      // .where('streams.userId = :id', { id: userId })
+      .where('streams.creatorId IN (:id)', { id: creatorIds })
       .andWhere('streams.startDate > DATE_SUB(NOW(), INTERVAL 10 DAY)')
       .getMany()
       .catch((err) => {

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -96,6 +96,30 @@ export class UsersService {
   }
 
   /**
+   * 특정 유저의 연동된 플랫폼 creatorId들의 정보 반환 (afreecaId, twitchId,,.)
+   * @param userId creatorId 얻고자 하는 유저id
+   */
+  async findOneCreatorIds(userId: string): Promise<string[]> {
+    const user = await this.usersRepository.findOne(userId, {
+      relations: ['twitch', 'afreeca', 'youtube'],
+    });
+
+    const creatorIds = [];
+
+    if (user.afreeca) {
+      creatorIds.push(user.afreeca.afreecaId);
+    }
+
+    if (user.twitch) {
+      creatorIds.push(user.twitch.twitchId);
+    }
+    if (user.youtube) {
+      creatorIds.push(user.youtube.youtubeId);
+    }
+    return creatorIds;
+  }
+
+  /**
    * 특정 유저의 연동된 플랫폼의 프로필 이미지 정보를 반환하는 메서드
    * @param userId 프로필 이미지 정보를 열람하고자 하는 유저 아이디
    */

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -463,6 +463,7 @@ export class UsersService {
           'users.nickName AS nickname',
         ])
         .where('streams.platform = :platform', { platform })
+        .andWhere('streams.needAnalysis = 0') // needAnalysis 가 0인 stream 데이터만
         .groupBy('streams.creatorId')
         .orderBy('MAX(streams.endDate)', 'DESC')
         .getRawMany();


### PR DESCRIPTION
문제상황 : 트루포인트 production 환경에서 streams, streamSummary, ranking 테이블에 데이터가 있음에도 불구하고,  편집점 분석 페이지에서 달력에 해당 방송 데이터가 표시되지 않음

원인 : typeorm sync 기능은 테이블 컬럼이 변경되었을 때 컬럼을 삭제한 뒤 새로 만듦. 그래서 기존에 입력되었던 데이터(아마 userId값)가 사라짐

현재 브랜치에서 취한 조치 : 
1. userId로 조회하는 부분에서 userId에 연동된 creatorId를 찾아서
2. Streams 테이블 조회시 where streams.userId = userId 로 조회하는 부분을 where streams.creatorId IN (twitchId,afreecaId) 로 변경함 

위 작업을 적용한 라우터
- GET /broadcast-info (편집점 분석 달력에서 사용)
- GET /user-statistics (마이페이지 대시보드 컴포넌트에서 사용)

TODO(해결하지 못한 문제):
- typeorm migration적용
- 두 라우터 제외하고 다른 부분에서 userId로 조회하는 부분을 찾아서 creatorId로 조회하도록 수정
- 유투브편집점 살펴보기 페이지에서 일부 예시화면 처럼 보이는 문제 #246

기타 수정사항
- 유투브 편집점 페이지에 나오는 목록에서 streams.needAnalysis값이 1인 방송은 제외
- 유투브 편집점 페이지에서 대시보드로 이동하는 버튼 글자를 해당 방송제목 -> '편집점 분석'으로 변경(최신 방송 제목이 뜨지 않고 있음)