### PR TITLE
[TP #3.2] 방송 점수 상대적 위치 표현

### DIFF
--- a/client/web/src/organisms/mainpage/ranking/topten/ScoreBar.tsx
+++ b/client/web/src/organisms/mainpage/ranking/topten/ScoreBar.tsx
@@ -1,14 +1,33 @@
-import { LinearProgress, Typography } from '@material-ui/core';
+import { Grid, LinearProgress, Typography } from '@material-ui/core';
 import React, { useMemo } from 'react';
 import { useProgressBar, useTopTenList } from '../style/TopTenList.style';
 
 const MIN = 0;
+
+function getRankLabel({ total, scoreRank }: {
+  total: number | undefined,
+  scoreRank: number | undefined
+}): string | null {
+  if (!total || !scoreRank) return null;
+
+  const percentile = Math.round((scoreRank / total) * 100);
+
+  if (scoreRank < 20) return `랭킹 ${scoreRank}위`;
+  if (percentile < 30) return `상위 ${percentile}%`;
+  if (percentile > 70) return '거의 없는 편';
+
+  return '평범한 편';
+}
 interface Props{
   score: number;
+  total?: number;
+  scoreRank?: number;
   max?: number;
 }
 function ScoreBar(props: Props): JSX.Element {
-  const { score, max = 10 } = props;
+  const {
+    score, max = 10, total, scoreRank,
+  } = props;
   const progressBarStyles = useProgressBar();
   const classes = useTopTenList();
   /**
@@ -21,6 +40,9 @@ function ScoreBar(props: Props): JSX.Element {
   const normalizedScore = useMemo(() => (
     Number((((score - MIN) * 100) / (max - MIN) || 0).toFixed(2))
   ), [max, score]);
+
+  const rankLabel = getRankLabel({ total, scoreRank });
+
   return (
     <div>
       <LinearProgress
@@ -32,17 +54,21 @@ function ScoreBar(props: Props): JSX.Element {
         classes={progressBarStyles}
         value={Math.min(100, normalizedScore)}
       />
-      {score && (
-      <Typography
-        component="span"
-        className={classes.scoreText}
-        style={{
-          transform: `translateX(${(10 - score) * (-10)}%`,
-        }}
-      >
-        {score ? `${Math.min(10, Number(score.toFixed(2)))}` : 0}
-      </Typography>
-      )}
+      <Grid container justify="space-between">
+        {score && (
+        <Typography
+          component="span"
+          className={classes.scoreText}
+        >
+          {score ? `${Math.min(10, Number(score.toFixed(2)))}` : 0}
+        </Typography>
+        )}
+        { rankLabel && (
+        <Typography component="span" style={{ color: 'black', fontSize: '14px' }}>
+          {rankLabel}
+        </Typography>
+        )}
+      </Grid>
 
     </div>
 

--- a/client/web/src/organisms/mainpage/shared/ScoresSection.tsx
+++ b/client/web/src/organisms/mainpage/shared/ScoresSection.tsx
@@ -42,7 +42,12 @@ export function ScoresSection({ scores }: {
             </Typography>
           </Grid>
           <Grid item className={classes.scoreBarContainer}>
-            <ScoreBar score={scores[score.name]} />
+            <ScoreBar
+              total={scores.total}
+              scoreRank={scores[`${score.name}Rank` as const]}
+              score={scores[score.name]}
+            />
+
           </Grid>
         </Grid>
       ))}

--- a/shared/res/CreatorRatingResType.interface.ts
+++ b/shared/res/CreatorRatingResType.interface.ts
@@ -8,9 +8,21 @@ export interface CreatorAverageScores{
   frustrate: number,
   cuss: number
 }
+
+export interface CreatorAverageScoresWithRank{
+  admire: number,
+  smile: number,
+  frustrate: number,
+  cuss: number,
+  total: number,
+  admireRank: number,
+  smileRank: number,
+  frustrateRank: number,
+  cussRank: number,
+}
 export interface CreatorRatingInfoRes {
   ratings: CreatorAverageRatings,
-  scores: CreatorAverageScores,
+  scores: CreatorAverageScores | CreatorAverageScoresWithRank,
 }
 
 export interface WeeklyRatingRankingItem{


### PR DESCRIPTION
![스크린샷 2021-06-29 오후 3 08 08](https://user-images.githubusercontent.com/18395475/123745870-d48f3000-d8eb-11eb-9ed5-9e7c78bb0e69.png)
방송일 프로필 페이지 - 방송인의 1달 내 감정점수의 평균과 순위 표현 추가
— 순위 20위 이내 → (랭킹 그대로 표현)
— 상위 30% 이내인 경우 → 백분율로 표현. (ex. 상위 27%)
— 상위 30% ~ 상위 70% 인경우 → 평범한 편
— 상위 70% 이하인 경우 → 거의 없는 편

- 요청이 올 때마다 rank()함수를 사용해 순위 구하는 방식으로 만듦
- 다수 사용자를 가정하여 더 나은 방식으로 만들어야 함