### PR TITLE
방송 대 방송 분석 결과 - 카드 문구 스타일 수정

### DIFF
--- a/client/web/src/organisms/mypage/stream-analysis/StreamMetrics.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/StreamMetrics.tsx
@@ -25,7 +25,6 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
   },
   card: {
-    height: '94px',
     borderRadius: '4px',
     backgroundColor: '#959abb',
     borderWidth: 0,
@@ -87,11 +86,11 @@ export default function StreamAnalysis(
                         <CardContent className={classes.center}>
                           <Grid container direction="row" justify="center" spacing={1}>
                             <Grid item>
-                              <Typography className={classes.main}>
-                                {type ? '기준 기간' : `"${element.broad1Title}" ` }
+                              <Typography>
+                                {type ? '기준 기간' : <Typography component="span">{`"${element.broad1Title}" `}</Typography> }
                                 이
                                 {' '}
-                                {type ? '비교 기간' : `"${element.broad2Title}" ` }
+                                {type ? '비교 기간' : <Typography component="span">{`"${element.broad2Title}" `}</Typography> }
                                 보다
                                 {' '}
                                 {element.title}

--- a/client/web/src/organisms/mypage/stream-analysis/StreamMetrics.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/StreamMetrics.tsx
@@ -30,8 +30,7 @@ const useStyles = makeStyles((theme) => ({
     borderWidth: 0,
   },
   main: {
-    fontSize: '18px',
-    fontWeight: 'normal',
+    fontSize: theme.typography.h6.fontSize,
     color: theme.palette.text.primary,
   },
   bold: {
@@ -84,27 +83,25 @@ export default function StreamAnalysis(
                     <Grid item>
                       <Card className={classes.card} variant="outlined">
                         <CardContent className={classes.center}>
-                          <Grid container direction="row" justify="center" spacing={1}>
+                          <Grid container direction="row" justify="center">
                             <Grid item>
                               <Typography>
-                                {type ? '기준 기간' : <Typography component="span">{`"${element.broad1Title}" `}</Typography> }
-                                이
-                                {' '}
-                                {type ? '비교 기간' : <Typography component="span">{`"${element.broad2Title}" `}</Typography> }
+                                {type ? '기준 기간' : <Typography className={classes.main} component="span">{`"${element.broad1Title}" `}</Typography> }
+                                이&nbsp;
+                                {type ? '비교 기간' : <Typography className={classes.main} component="span">{`"${element.broad2Title}" `}</Typography> }
                                 보다
-                                {' '}
-                                {element.title}
-                                가
-                                {' '}
                               </Typography>
                             </Grid>
                             <Grid item>
-                              <Typography className={classnames(classes.main, classes.bold)}>
-                                {element.diff}
-                              </Typography>
-                            </Grid>
-                            <Grid item>
-                              <Typography className={classes.main}>
+                              <Typography gutterBottom className={classes.main}>
+                                <Typography component="span" className={classnames(classes.main, classes.bold)}>
+                                  {element.title}
+                                </Typography>
+                                가&nbsp;
+                                <Typography component="span" className={classnames(classes.main, classes.bold)}>
+                                  {element.diff}
+                                  &nbsp;
+                                </Typography>
                                 {element.sign ? '더 많습니다.' : '더 적습니다.'}
                               </Typography>
                             </Grid>

--- a/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
+++ b/client/web/src/organisms/mypage/stream-analysis/stream-vs-stream/StreamCompareSection.tsx
@@ -153,7 +153,7 @@ export default function StreamCompareSection(
         </Grid>
 
         {/* 선택된 방송 목록 */}
-        <Grid item xs container alignItems="center">
+        <Grid item xs container alignItems="center" wrap="nowrap">
           {/* 리스트 클릭시 base , compare 방송 정보 카드 렌더링 */}
           <Grid item>
             <StreamCard


### PR DESCRIPTION
![스크린샷 2021-07-16 오전 9 24 48](https://user-images.githubusercontent.com/18395475/125875988-70f16ee0-d5e8-4eb0-a3d9-56b75396dd71.png)
![스크린샷 2021-07-16 오전 9 56 04](https://user-images.githubusercontent.com/18395475/125875992-007c4b4f-f117-41a9-bc00-ae65a81ef121.png)
수정 전 | 수정 후 화면
- 선택된 방송 카드가 줄바뀜되는 현상 -> nowrap 속성 적용
- 결과 카드 높이가 고정이어서 글자가 보이지 않는 현상 -> 결과 카드 height 삭제