### PR TITLE
[tp 3.22] 닉네임 입력칸에 특정 이름('관리자') 사용 제한

### DIFF
--- a/client/web/src/organisms/mainpage/communityBoard/CommunityPostWrite.tsx
+++ b/client/web/src/organisms/mainpage/communityBoard/CommunityPostWrite.tsx
@@ -23,6 +23,7 @@ import useSunEditor from '../../../utils/hooks/useSunEditor';
 import usePostWriteEditAPI from '../../../utils/hooks/usePostWriteEditAPI';
 import WritingInputFields from './write/WritingInputFields';
 import useAuthContext from '../../../utils/hooks/useAuthContext';
+import { throwErrorIfNicknameOnBlacklist } from '../../../utils/checkAvailableNickname';
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   title: {
@@ -142,6 +143,7 @@ export default function CommunityPostWrite(): JSX.Element {
     };
 
     try {
+      throwErrorIfNicknameOnBlacklist(createPostDto.nickname);
       const nowContents = getHtmlFromEditor(editor);
       const imageResoureces = replaceResources(nowContents);
       createPostDto.content = imageResoureces.content;

--- a/client/web/src/organisms/mainpage/communityBoard/list/PostList.tsx
+++ b/client/web/src/organisms/mainpage/communityBoard/list/PostList.tsx
@@ -14,8 +14,8 @@ import CenterLoading from '../../../../atoms/Loading/CenterLoading';
 import { useStyles, rowHeightBase } from '../style/PostList.style';
 import useMediaSize from '../../../../utils/hooks/useMediaSize';
 import SmileIcon from '../../../../atoms/svgIcons/SmileIcon';
-import transformIdToAsterisk from '../../../../utils/transformAsterisk';
 import { dayjsFormatter } from '../../../../utils/dateExpression';
+import { displayNickname } from '../../../../utils/checkAvailableNickname';
 
 interface PostListProps {
   take: number,
@@ -116,9 +116,7 @@ function DesktopPostList({
           {post.repliesCount ? <span className={classes.replies}>{`[${post.repliesCount}]`}</span> : null}
         </>
       ),
-      nickname: post.userId
-        ? `${post.nickname} (${transformIdToAsterisk(post.userId)})`
-        : post.nickname,
+      nickname: displayNickname(post.userId, post.nickname as string),
       createDate: `${getDateDisplay(post.createDate)}`,
       hit: post.hit,
       recommend: post.recommend,
@@ -232,9 +230,7 @@ function MobilePostList({
                     : post.title}
                 </Typography>
                 <Typography className={classnames(classes.mobileText, classes.mobileNickname)}>
-                  { post.userId
-                    ? `${post.nickname} (${transformIdToAsterisk(post.userId)})`
-                    : post.nickname}
+                  {displayNickname(post.userId, post.nickname as string)}
                 </Typography>
 
               </Grid>

--- a/client/web/src/organisms/mainpage/communityBoard/postView/PostInfoCard.tsx
+++ b/client/web/src/organisms/mainpage/communityBoard/postView/PostInfoCard.tsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { CommunityPost } from '@truepoint/shared/dist/interfaces/CommunityPost.interface';
 import useMediaSize from '../../../../utils/hooks/useMediaSize';
 import { dayjsFormatter } from '../../../../utils/dateExpression';
-import transformIdToAsterisk from '../../../../utils/transformAsterisk';
+import { displayNickname } from '../../../../utils/checkAvailableNickname';
 
 const usePostInfoCardStyle = makeStyles((theme: Theme) => createStyles({
   postInfoCard: {
@@ -73,7 +73,7 @@ function PostInfoCard({ post, repliesCount }: PostProps) {
       <Grid container justify="space-between">
         <Grid item className={cardClass.group} xs={12} sm={6}>
           <Typography className="text">
-            {`${nickname} ${userId ? `(${transformIdToAsterisk(userId)})` : ''}`}
+            {displayNickname(userId, nickname)}
           </Typography>
           <Divider orientation="vertical" flexItem />
           <Typography className={classnames('text', cardClass.date)}>

--- a/client/web/src/organisms/mainpage/featureSuggestion/sub/FeatureReply.tsx
+++ b/client/web/src/organisms/mainpage/featureSuggestion/sub/FeatureReply.tsx
@@ -65,7 +65,9 @@ export default function FeatureReply({
         <div>
           <div className={classes.titleSection}>
             <Typography variant="body2" className={classes.title}>
-              {transformIdToAsterisk(reply.author?.userId ? reply.author?.userId : reply.userIp)}
+              {reply.author?.userId === 'Truepoint'
+                ? reply.author?.userId
+                : transformIdToAsterisk(reply.author?.userId ? reply.author?.userId : reply.userIp)}
             </Typography>
             <Typography variant="caption">{dayjsFormatter(reply.createdAt).fromNow()}</Typography>
             {reply.author?.userId !== 'Truepoint' && (

--- a/client/web/src/organisms/mainpage/ranking/UserReactionCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/UserReactionCard.tsx
@@ -10,10 +10,12 @@ import { useSnackbar } from 'notistack';
 import React, { useCallback, useEffect, useRef } from 'react';
 import CenterLoading from '../../../atoms/Loading/CenterLoading';
 import ShowSnack from '../../../atoms/snackbar/ShowSnack';
+import { isAvailableNickname } from '../../../utils/checkAvailableNickname';
 import { useUserReactionStyle } from './style/UserReactionCard.style';
 import UserReactionListItem from './sub/UserReactionListItem';
 
 const userReactionUrl = '/user-reactions';
+
 export default function UserReactionCard(): JSX.Element {
   const classes = useUserReactionStyle();
   const { enqueueSnackbar } = useSnackbar();
@@ -68,10 +70,17 @@ export default function UserReactionCard(): JSX.Element {
     if (!formRef.current) {
       return;
     }
+
+    const userNickname = formRef.current.username.value.trim();
+    if (!isAvailableNickname(userNickname)) {
+      ShowSnack('사용할 수 없는 닉네임입니다. 다른 닉네임을 입력해주세요.', 'error', enqueueSnackbar);
+      return;
+    }
     if (formRef.current.content.value.trim() === '' || formRef.current.password.value.trim() === '') {
       ShowSnack('비밀번호와 내용을 입력해주세요', 'error', enqueueSnackbar);
       return;
     }
+
     createUserReaction({
       username: formRef.current.username.value.trim() || '시청자',
       password: formRef.current.password.value,

--- a/client/web/src/organisms/mainpage/ranking/UserReactionCard.tsx
+++ b/client/web/src/organisms/mainpage/ranking/UserReactionCard.tsx
@@ -10,7 +10,7 @@ import { useSnackbar } from 'notistack';
 import React, { useCallback, useEffect, useRef } from 'react';
 import CenterLoading from '../../../atoms/Loading/CenterLoading';
 import ShowSnack from '../../../atoms/snackbar/ShowSnack';
-import { isAvailableNickname } from '../../../utils/checkAvailableNickname';
+import { isAvailableNickname, UNAVAILABLE_NICKNAME_ERROR_MESSAGE } from '../../../utils/checkAvailableNickname';
 import { useUserReactionStyle } from './style/UserReactionCard.style';
 import UserReactionListItem from './sub/UserReactionListItem';
 
@@ -73,7 +73,7 @@ export default function UserReactionCard(): JSX.Element {
 
     const userNickname = formRef.current.username.value.trim();
     if (!isAvailableNickname(userNickname)) {
-      ShowSnack('사용할 수 없는 닉네임입니다. 다른 닉네임을 입력해주세요.', 'error', enqueueSnackbar);
+      ShowSnack(UNAVAILABLE_NICKNAME_ERROR_MESSAGE, 'error', enqueueSnackbar);
       return;
     }
     if (formRef.current.content.value.trim() === '' || formRef.current.password.value.trim() === '') {

--- a/client/web/src/organisms/mainpage/ranking/sub/CommentForm.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/CommentForm.tsx
@@ -6,6 +6,7 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 import ShowSnack from '../../../../atoms/snackbar/ShowSnack';
 import axios from '../../../../utils/axios';
+import { isAvailableNickname, UNAVAILABLE_NICKNAME_ERROR_MESSAGE } from '../../../../utils/checkAvailableNickname';
 import useAuthContext from '../../../../utils/hooks/useAuthContext';
 import { useCreatorCommentFormStyle } from '../style/CreatorComment.style';
 
@@ -62,6 +63,11 @@ export default function CommentForm(props: CommentFormProps): JSX.Element {
       createCommentDto.nickname = nickname;
       createCommentDto.password = password;
       createCommentDto.content = content;
+    }
+
+    if (!isAvailableNickname(createCommentDto.nickname)) {
+      ShowSnack(UNAVAILABLE_NICKNAME_ERROR_MESSAGE, 'error', enqueueSnackbar);
+      return;
     }
 
     axios.post(postUrl, { ...createCommentDto })

--- a/client/web/src/organisms/mainpage/ranking/sub/CommentItem.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/CommentItem.tsx
@@ -12,7 +12,6 @@ import useAuthContext from '../../../../utils/hooks/useAuthContext';
 import useDialog from '../../../../utils/hooks/useDialog';
 import useMediaSize from '../../../../utils/hooks/useMediaSize';
 import useToggle from '../../../../utils/hooks/useToggle';
-import transformIdToAsterisk from '../../../../utils/transformAsterisk';
 import { dayjsFormatter } from '../../../../utils/dateExpression';
 import { useCreatorCommentItemStyle } from '../style/CreatorComment.style';
 import CommentForm from './CommentForm';
@@ -20,6 +19,7 @@ import DeleteButton from './DeleteButton';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
 import PasswordConfirmDialog from './PasswordConfirmDialog';
 import ReportConfirmDialog from './ReportConfirmDialog';
+import { displayNickname } from '../../../../utils/checkAvailableNickname';
 
 export interface CommentItemProps extends Record<string, any>{
   /** 대상이 되는 댓글(commentId), 글(postId), 크리에이터(creatorId) */
@@ -258,11 +258,15 @@ export default function CommentItem(props: CommentItemProps): JSX.Element {
     <div className={classnames(classes.commentItem, { child: childComment })} id={`commentId-${commentId}`}>
       <div className={classes.header}>
         <div className={classes.userInfo}>
-          <Avatar component="span" className={classes.smallAvatar} src={profileImage} />
+          <Avatar
+            component="span"
+            className={classes.smallAvatar}
+            src={userId !== 'Truepoint'
+              ? profileImage
+              : '/images/favicon/android-icon-36x36.png'}
+          />
           <Typography component="span" className="nickname">
-            { userId
-              ? `${nickname} (${transformIdToAsterisk(userId)})`
-              : nickname}
+            { displayNickname(userId, nickname)}
           </Typography>
         </div>
         <div className={classes.headerActions}>

--- a/client/web/src/organisms/mainpage/ranking/sub/UserReactionListItem.tsx
+++ b/client/web/src/organisms/mainpage/ranking/sub/UserReactionListItem.tsx
@@ -48,13 +48,13 @@ function UserReactionListItem(props: UserReactionListItemProps): JSX.Element {
   const classes = useUserReactionListItemStyle();
   const { data, reloadItems } = props;
   const {
-    username, content, id,
+    username, content, id, createDate, userId,
   } = data;
 
   const inputRef = useRef<HTMLInputElement>(null);
   const { open: isPasswordDialogOpen, handleOpen: openPasswordDialog, handleClose: closePasswordDialog } = useDialog();
   const { open: isConfirmDialogOpen, handleOpen: openConfirmDialog, handleClose: closeConfirmDialog } = useDialog();
-  const date = dayjsFormatter(data.createDate, 'hh:mm A');
+  const date = dayjsFormatter(createDate, 'hh:mm A');
 
   const onDeleteButtonClick = useCallback(() => {
     openPasswordDialog();
@@ -102,7 +102,10 @@ function UserReactionListItem(props: UserReactionListItemProps): JSX.Element {
     <>
       <ListItem alignItems="flex-start">
         <ListItemAvatar className={classes.avatarContainer}>
-          <Avatar className={classes.avatar} />
+          {userId === 'Truepoint'
+            ? <Avatar className={classes.avatar} src="/images/favicon/android-icon-36x36.png" />
+            : <Avatar className={classes.avatar} />}
+
         </ListItemAvatar>
         <ListItemText
           classes={{ primary: classes.itemPrimaryText }}

--- a/client/web/src/utils/checkAvailableNickname.ts
+++ b/client/web/src/utils/checkAvailableNickname.ts
@@ -1,0 +1,10 @@
+const nicknameBlackList = [
+  '관리자',
+  'truepoint',
+];
+
+export function isAvailableNickname(nick: string): boolean {
+  const trimmedLowercase = nick.replace(/ /g, '').toLowerCase();
+  const includedInBlackList = nicknameBlackList.includes(trimmedLowercase);
+  return !includedInBlackList;
+}

--- a/client/web/src/utils/checkAvailableNickname.ts
+++ b/client/web/src/utils/checkAvailableNickname.ts
@@ -1,18 +1,35 @@
-const nicknameBlackist = [
+import transformIdToAsterisk from './transformAsterisk';
+
+const nicknameBlacklist = [
   '관리자',
   'truepoint',
 ];
 
 export const UNAVAILABLE_NICKNAME_ERROR_MESSAGE = '사용할 수 없는 닉네임입니다. 다른 닉네임을 입력해주세요.';
 
+/**
+ * 닉네임이 블랙리스트에 해당되면 false 반환(사용 불가 닉네임)
+ */
 export function isAvailableNickname(nick: string): boolean {
   const trimmedLowercase = nick.replace(/ /g, '').toLowerCase();
-  const includedInBlackList = nicknameBlackist.includes(trimmedLowercase);
-  return !includedInBlackList;
+  return !nicknameBlacklist.includes(trimmedLowercase);
 }
 
 export function throwErrorIfNicknameOnBlacklist(nick: string): never | void {
   if (!isAvailableNickname(nick)) {
     throw new Error(UNAVAILABLE_NICKNAME_ERROR_MESSAGE);
   }
+}
+
+/**
+ * userId가 있는 경우 
+ *  "닉네임 (아이디**)"" 형태로 표시
+ * userId가 없는 경우
+ *  "닉네임" 만 표시
+ */
+export function displayNickname(userId: string | undefined, nickname: string): string {
+  if (!userId) return nickname;
+  return (userId !== 'Truepoint')
+    ? `${nickname} (${transformIdToAsterisk(userId)})`
+    : nickname;
 }

--- a/client/web/src/utils/checkAvailableNickname.ts
+++ b/client/web/src/utils/checkAvailableNickname.ts
@@ -1,10 +1,18 @@
-const nicknameBlackList = [
+const nicknameBlackist = [
   '관리자',
   'truepoint',
 ];
 
+export const UNAVAILABLE_NICKNAME_ERROR_MESSAGE = '사용할 수 없는 닉네임입니다. 다른 닉네임을 입력해주세요.';
+
 export function isAvailableNickname(nick: string): boolean {
   const trimmedLowercase = nick.replace(/ /g, '').toLowerCase();
-  const includedInBlackList = nicknameBlackList.includes(trimmedLowercase);
+  const includedInBlackList = nicknameBlackist.includes(trimmedLowercase);
   return !includedInBlackList;
+}
+
+export function throwErrorIfNicknameOnBlacklist(nick: string): never | void {
+  if (!isAvailableNickname(nick)) {
+    throw new Error(UNAVAILABLE_NICKNAME_ERROR_MESSAGE);
+  }
 }

--- a/server/.adminbro/.entry.js
+++ b/server/.adminbro/.entry.js
@@ -5,7 +5,13 @@ import Component2 from '../dist/admin-panel/components/community-post-category-l
 AdminBro.UserComponents.Component2 = Component2
 import Component3 from '../dist/admin-panel/components/community-post-link'
 AdminBro.UserComponents.Component3 = Component3
-import Component4 from '../dist/admin-panel/components/creator-comment-link'
+import Component4 from '../dist/admin-panel/components/comment-for-post'
 AdminBro.UserComponents.Component4 = Component4
-import Component5 from '../dist/admin-panel/components/featureSuggestion-state-label'
+import Component5 from '../dist/admin-panel/components/child-comment-for-post-comment'
 AdminBro.UserComponents.Component5 = Component5
+import Component6 from '../dist/admin-panel/components/creator-comment-link'
+AdminBro.UserComponents.Component6 = Component6
+import Component7 from '../dist/admin-panel/components/child-comment-for-creator-comment'
+AdminBro.UserComponents.Component7 = Component7
+import Component8 from '../dist/admin-panel/components/featureSuggestion-state-label'
+AdminBro.UserComponents.Component8 = Component8

--- a/server/src/admin-panel/admin-panel.options.ts
+++ b/server/src/admin-panel/admin-panel.options.ts
@@ -68,6 +68,7 @@ export const getAdminOptions = (...args: any[]): AdminModuleOptions | Promise<Ad
               notRecommendCount: '비추',
               platform: '게시판',
               category: '분류',
+              userId: 'userId - *** 관리자인 경우 "Truepoint" 입력 ***',
             },
           },
           FeatureSuggestionEntity: {

--- a/server/src/admin-panel/admin-panel.options.ts
+++ b/server/src/admin-panel/admin-panel.options.ts
@@ -85,6 +85,7 @@ export const getAdminOptions = (...args: any[]): AdminModuleOptions | Promise<Ad
           UserReactionEntity: {
             properties: {
               username: '닉네임',
+              userId: 'userId - *** 관리자인 경우 "Truepoint" 입력 ***',
             },
           },
           CommunityReplyEntity: {

--- a/server/src/admin-panel/components/child-comment-for-creator-comment.tsx
+++ b/server/src/admin-panel/components/child-comment-for-creator-comment.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import axios from 'axios';
+import getApiHost from '../../utils/getApiHost';
+
+type Props = Record<string, any>
+
+const CreateChildCommentForPostComment = ({ record }: Props): JSX.Element => {
+  const { params } = record;
+  const { parentCommentId, commentId } = params;
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const content = form.textarea.value.trim();
+
+    if (!content) {
+      alert('내용을 작성해주세요');
+      return;
+    }
+    axios({
+      url: `${getApiHost()}/creatorComment/replies/${commentId}`,
+      method: 'post',
+      data: {
+        userId: 'Truepoint',
+        nickname: '관리자',
+        password: '',
+        content: form.textarea.value,
+      },
+    }).then(() => {
+      form.textarea.value = '';
+      alert('작성 성공');
+    })
+      .catch((error) => {
+        console.error(error);
+        alert('작성 실패');
+      });
+  };
+
+  if (parentCommentId) return null; // 자식댓글인경우 대댓글 못달게되어있음
+
+  return (
+    <form style={{ marginBottom: 32 }} onSubmit={onSubmit}>
+      <p>해당 댓글에 관리자로 댓글 달기</p>
+      <textarea name="textarea" maxLength={100} style={{ width: '100%', resize: 'none', padding: 8 }} />
+      <button type="submit">댓글 달기</button>
+    </form>
+
+  );
+};
+
+export default CreateChildCommentForPostComment;

--- a/server/src/admin-panel/components/child-comment-for-post-comment.tsx
+++ b/server/src/admin-panel/components/child-comment-for-post-comment.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import axios from 'axios';
+import getApiHost from '../../utils/getApiHost';
+
+type Props = Record<string, any>
+
+const CreateChildCommentForPostComment = ({ record }: Props): JSX.Element => {
+  const { params } = record;
+  const { replyId, parentReplyId } = params;
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const content = form.textarea.value.trim();
+
+    if (!content) {
+      alert('내용을 작성해주세요');
+      return;
+    }
+    axios({
+      url: `${getApiHost()}/community/replies/child/${replyId}`,
+      method: 'post',
+      data: {
+        userId: 'Truepoint',
+        nickname: '관리자',
+        password: '',
+        content: form.textarea.value,
+      },
+    }).then(() => {
+      form.textarea.value = '';
+      alert('작성 성공');
+    })
+      .catch((error) => {
+        console.error(error);
+        alert('작성 실패');
+      });
+  };
+
+  if (parentReplyId) return null; // 자식댓글이므로 대댓글 못닮
+
+  return (
+    <form style={{ marginBottom: 32 }} onSubmit={onSubmit}>
+      <p>해당 댓글에 관리자로 댓글 달기</p>
+      <textarea name="textarea" maxLength={100} style={{ width: '100%', resize: 'none', padding: 8 }} />
+      <button type="submit">댓글 달기</button>
+    </form>
+
+  );
+};
+
+export default CreateChildCommentForPostComment;

--- a/server/src/admin-panel/components/comment-for-post.tsx
+++ b/server/src/admin-panel/components/comment-for-post.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import axios from 'axios';
+import getApiHost from '../../utils/getApiHost';
+
+type Props = Record<string, any>
+
+const CreateCommentForPost = ({ record }: Props): JSX.Element => {
+  const { params } = record;
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const content = form.textarea.value.trim();
+
+    if (!content) {
+      alert('내용을 작성해주세요');
+      return;
+    }
+    axios({
+      url: `${getApiHost()}/community/posts/${params.postId}/replies`,
+      method: 'post',
+      data: {
+        userId: 'Truepoint',
+        nickname: '관리자',
+        password: '',
+        content: form.textarea.value,
+      },
+    }).then(() => {
+      form.textarea.value = '';
+      alert('작성 성공');
+    })
+      .catch((error) => {
+        console.error(error);
+        alert('작성 실패');
+      });
+  };
+
+  return (
+    <form style={{ marginBottom: 32 }} onSubmit={onSubmit}>
+      <p>해당 글에 관리자로 댓글 달기</p>
+      <textarea name="textarea" maxLength={100} style={{ width: '100%', resize: 'none', padding: 8 }} />
+      <button type="submit">댓글 달기</button>
+    </form>
+
+  );
+};
+
+export default CreateCommentForPost;

--- a/server/src/admin-panel/config.ts
+++ b/server/src/admin-panel/config.ts
@@ -10,6 +10,12 @@ export const filterOnly = {
 export const showOnly = {
   list: false, show: true, edit: false, filter: false,
 };
+export const listAndShowOnly = {
+  list: true, show: true, edit: false, filter: false,
+};
+export const editOnly = {
+  list: false, show: false, edit: true, filter: false,
+};
 
 type SORT = {
   direction: 'desc' | 'asc';

--- a/server/src/admin-panel/resources/community-post.resource.ts
+++ b/server/src/admin-panel/resources/community-post.resource.ts
@@ -1,6 +1,6 @@
 import AdminBro, { ResourceWithOptions } from 'admin-bro';
 import { CommunityPostEntity } from '../../resources/communityBoard/entities/community-post.entity';
-import { CREATE_DATE__DESC, showOnly } from '../config';
+import { CREATE_DATE__DESC, showOnly, listAndShowOnly } from '../config';
 
 const PLATFORM_LABEL = AdminBro.bundle('../components/community-post-platform-label.tsx');
 const CATEGORY_LABEL = AdminBro.bundle('../components/community-post-category-label.tsx');
@@ -59,6 +59,11 @@ const CommunityPostResource: ResourceWithOptions = {
         isVisible: showOnly,
         position: 3,
       },
+      password: { isVisible: false },
+      hit: { isVisible: listAndShowOnly },
+      recommend: { isVisible: listAndShowOnly },
+      notRecommendCount: { isVisible: listAndShowOnly },
+      ip: { isVisible: listAndShowOnly },
     },
     navigation: {
       name: '글',

--- a/server/src/admin-panel/resources/community-post.resource.ts
+++ b/server/src/admin-panel/resources/community-post.resource.ts
@@ -5,6 +5,7 @@ import { CREATE_DATE__DESC, showOnly } from '../config';
 const PLATFORM_LABEL = AdminBro.bundle('../components/community-post-platform-label.tsx');
 const CATEGORY_LABEL = AdminBro.bundle('../components/community-post-category-label.tsx');
 const LINK = AdminBro.bundle('../components/community-post-link.tsx');
+const CREATE_COMMENT_FOR_POST = AdminBro.bundle('../components/comment-for-post');
 
 const CommunityPostResource: ResourceWithOptions = {
   resource: CommunityPostEntity,
@@ -24,7 +25,7 @@ const CommunityPostResource: ResourceWithOptions = {
     properties: {
       postId: { isId: true },
       title: { isTitle: true },
-      content: { type: 'richtext' },
+      content: { type: 'richtext', position: 1 },
       platform: {
         components: {
           list: PLATFORM_LABEL,
@@ -51,6 +52,12 @@ const CommunityPostResource: ResourceWithOptions = {
           show: LINK, // 글 상세보기 페이지에서 이미지, 동영상이 깨지는 문제 해결 못함. 임시로 해당 글로 이동하는 링크 추가
         },
         isVisible: showOnly,
+        position: 2,
+      },
+      createCommentForThisPost: {
+        components: { show: CREATE_COMMENT_FOR_POST },
+        isVisible: showOnly,
+        position: 3,
       },
     },
     navigation: {

--- a/server/src/admin-panel/resources/community-reply.resource.ts
+++ b/server/src/admin-panel/resources/community-reply.resource.ts
@@ -1,14 +1,36 @@
-import { ResourceWithOptions } from 'admin-bro';
-import { CREATE_DATE__DESC } from '../config';
+import AdminBro, { ResourceWithOptions } from 'admin-bro';
+import { CREATE_DATE__DESC, showOnly } from '../config';
 import { CommunityReplyEntity } from '../../resources/communityBoard/entities/community-reply.entity';
+
+const CREATE_CHILD_COMMENT_FOR_PARENT = AdminBro.bundle('../components/child-comment-for-post-comment');
 
 const CommunityReplyResource: ResourceWithOptions = {
   resource: CommunityReplyEntity,
   options: {
     sort: CREATE_DATE__DESC,
     listProperties: [
+      'replyId',
+      'nickname',
+      'content',
+      'createDate',
+      'ip',
+      'postId',
+      'userId',
+      'deleteFlag',
+      'reportCount',
+      'parentReplyId',
     ],
+    actions: {
+      new: { isVisible: false },
+    },
     properties: {
+      content: { position: 1 },
+      parentReplyId: { position: 2 },
+      createChildComment: {
+        components: { show: CREATE_CHILD_COMMENT_FOR_PARENT },
+        isVisible: showOnly,
+        position: 3,
+      },
     },
     navigation: {
       name: '댓글',

--- a/server/src/admin-panel/resources/creatorComments.resource.ts
+++ b/server/src/admin-panel/resources/creatorComments.resource.ts
@@ -18,9 +18,16 @@ const CreatorCommentsResource: ResourceWithOptions = {
       'creatorId',
       'parentCommentId',
     ],
+    actions: {
+      new: { isVisible: false },
+    },
     properties: {
       commentId: { isId: true },
-      content: { isTitle: true },
+      content: { isTitle: true, position: 1 },
+      createComment: {
+        components: { show: AdminBro.bundle('../components/child-comment-for-creator-comment') },
+        position: 2,
+      },
       link: {
         components: {
           show: LINK, // 댓글이 달린 방송인 프로필 페이지로 이동

--- a/server/src/admin-panel/resources/creatorComments.resource.ts
+++ b/server/src/admin-panel/resources/creatorComments.resource.ts
@@ -26,6 +26,7 @@ const CreatorCommentsResource: ResourceWithOptions = {
       content: { isTitle: true, position: 1 },
       createComment: {
         components: { show: AdminBro.bundle('../components/child-comment-for-creator-comment') },
+        isVisible: showOnly,
         position: 2,
       },
       link: {

--- a/server/src/admin-panel/resources/featurSuggestionReply.resource.ts
+++ b/server/src/admin-panel/resources/featurSuggestionReply.resource.ts
@@ -10,6 +10,9 @@ const FeatureSuggestionReplyResource: ResourceWithOptions = {
     ],
     properties: {
     },
+    actions: {
+      new: { isVisible: false },
+    },
     navigation: {
       name: '댓글',
       icon: '',

--- a/server/src/resources/communityBoard/communityBoard.controller.ts
+++ b/server/src/resources/communityBoard/communityBoard.controller.ts
@@ -15,7 +15,7 @@ import {
 } from '@nestjs/common';
 import { CreateCommunityPostDto } from '@truepoint/shared/dist/dto/communityBoard/createCommunityPost.dto';
 import { UpdateCommunityPostDto } from '@truepoint/shared/dist/dto/communityBoard/updateCommunityPost.dto';
-import { CreateReplyDto } from '@truepoint/shared/dist/dto/communityBoard/createReply.dto';
+import { CreateCommentDto } from '@truepoint/shared/dist/dto/creatorComment/createComment.dto';
 import { UpdateReplyDto } from '@truepoint/shared/dist/dto/communityBoard/updateReply.dto';
 import { FindPostResType } from '@truepoint/shared/dist/res/FindPostResType.interface';
 import { FindReplyResType } from '@truepoint/shared/dist/res/FindReplyResType.interface';
@@ -71,6 +71,7 @@ export class CommunityBoardController {
    * @param qtext 검색어
    * @param qtype 'title' | 'nickname', 제목 검색 | 작성자 검색
    */
+  // eslint-disable-next-line max-params
   @Get('posts')
   findAllPosts(
     @Query('platform') platform: string,
@@ -226,7 +227,7 @@ export class CommunityBoardController {
   createReply(
     @Ip() userIp: string,
     @Param('postId', ParseIntPipe) postId: number,
-    @Body() createReplyDto: CreateReplyDto,
+    @Body() createReplyDto: CreateCommentDto,
   ): Promise<CommunityReplyEntity> {
     return this.communityReplyService.createReply(postId, createReplyDto, userIp);
   }
@@ -236,7 +237,7 @@ export class CommunityBoardController {
   createChildReply(
     @Ip() userIp: string,
     @Param('replyId', ParseIntPipe) replyId: number,
-    @Body() createReplyDto: CreateReplyDto,
+    @Body() createReplyDto: CreateCommentDto,
   ): Promise<CommunityReplyEntity> {
     return this.communityReplyService.createChildReply({
       parentReplyId: replyId,

--- a/server/src/resources/userReaction/entities/userReaction.entity.ts
+++ b/server/src/resources/userReaction/entities/userReaction.entity.ts
@@ -23,4 +23,7 @@ export class UserReactionEntity extends BaseEntity implements UserReaction {
 
   @Column({ select: false, comment: 'bcrypt로 암호화된 비밀번호' })
   password: string;
+
+  @Column({ nullable: true, default: null, comment: '작성자 userId, 관리자인 경우 Truepoint 로 저장한다' })
+  userId: string;
 }

--- a/shared/interfaces/UserReaction.interface.ts
+++ b/shared/interfaces/UserReaction.interface.ts
@@ -5,4 +5,5 @@ export interface UserReaction{
   content: string;
   createDate: Date;
   password: string;
+  userId: string;
 }


### PR DESCRIPTION
트포 웹 닉네임 입력 가능한 곳에서 ['관리자', 'Truepoint'] 를 닉네임으로 입력 시, 사용할 수 없는 닉네임이라는  스낵바 띄움
- 잡담방
- 자유게시판
- 방송인 프로필 페이지 댓글
- 자유게시판 댓글

관리자페이지(Truepoint 관리자 웹 > db admin으로 이동)에서 '관리자' 닉네임으로 작성 가능하도록 수정
- 잡담방 - `잡담방 > Create New 클릭` 닉네임 자유 입력 가능, userId에 Truepoint 입력할것
- 자유게시판 글 -  `자유게시판 글 > Create New 클릭` 닉네임 자유 입력 가능, userId에 Truepoint 입력할것
- 자유게시판 댓글 - `자유게시판 글 > 댓글달 글 클릭` 닉네임 '관리자' 고정
- 자유게시판 대댓글 - `자유게시판 댓글 > 대댓글 달 댓글 클릭` 닉네임 '관리자' 고정
- 방송인 프로필 페이지 대댓글 - `방송인 프로필 페이지 댓글 > 대댓글 달 댓글 클릭` 닉네임 '관리자' 고정