### PR TITLE
[수정요청] 아이디, 비밀번호 찾기 시 '이름' 입력칸 삭제

### DIFF
--- a/client/web/src/organisms/mainpage/login/FindIdForm.tsx
+++ b/client/web/src/organisms/mainpage/login/FindIdForm.tsx
@@ -65,7 +65,6 @@ export default function FindAccountForm(): JSX.Element {
 
   // **************************************************
   // Input values
-  const usernameRef = useRef<HTMLInputElement>(null);
   const usermailRef = useRef<HTMLInputElement>(null);
 
   // **************************************************
@@ -76,11 +75,10 @@ export default function FindAccountForm(): JSX.Element {
   );
   function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
     e.preventDefault();
-    if (usernameRef.current && usermailRef.current) {
-      const username = usernameRef.current.value;
+    if (usermailRef.current) {
       const usermail = usermailRef.current.value;
       getRequest({
-        params: { name: username, mail: usermail },
+        params: { mail: usermail },
       }).then((res) => {
         if (res.data) {
           const { userId } = res.data;
@@ -145,7 +143,7 @@ export default function FindAccountForm(): JSX.Element {
             }}
             className={classes.selectButton}
           >
-            <Typography variant="body1">이메일 및 이름으로 아이디 찾기</Typography>
+            <Typography variant="body1">이메일로 아이디 찾기</Typography>
           </Button>
 
           {/* 휴대폰 본인인증은 추후 기획에 따라 지원 */}
@@ -161,25 +159,17 @@ export default function FindAccountForm(): JSX.Element {
       </div>
       )}
 
-      {/* 방법에 따른 정보 입력 - 이메일 및 이름 */}
+      {/* 방법에 따른 정보 입력 - 이메일 */}
       {activeStep === 1 && selectedMethod === '이메일' && (
       <div className={classnames(classes.box, classes.content)}>
-        <Typography variant="h6">이메일, 이름으로</Typography>
+        <Typography variant="h6">이메일로</Typography>
         <Typography variant="h6">아이디를 찾습니다.</Typography>
         <Typography className={classes.subcontent} variant="body2">
-          {/* 가입시 입력한 이메일과 본인인증시 사용된 본명으로 아이디를 찾습니다. */}
-          가입시 입력한 이메일과 이름으로 아이디를 찾습니다.
+          {/* 가입시 입력한 이메일로 아이디를 찾습니다. */}
+          가입시 입력한 이메일로 아이디를 찾습니다.
         </Typography>
         <form className={classes.content} onSubmit={handleSubmit}>
-          <TextField
-            color="primary"
-            type="text"
-            label="이름"
-            inputRef={usernameRef}
-            autoComplete="off"
-            className={classes.inputField}
-            inputProps={{ required: true, minLength: 3 }}
-          />
+
           <TextField
             color="primary"
             type="email"

--- a/client/web/src/pages/others/GetTemporaryPassword.tsx
+++ b/client/web/src/pages/others/GetTemporaryPassword.tsx
@@ -51,13 +51,13 @@ export default function GetTemporaryPassword(): JSX.Element {
   // **************************************************
   // inputRef
   const userIdRef = useRef<HTMLInputElement>(null);
-  const usernameRef = useRef<HTMLInputElement>(null);
+  // const usernameRef = useRef<HTMLInputElement>(null);
   const usermailRef = useRef<HTMLInputElement>(null);
 
   // **************************************************
   // 임시 비밀번호 발급 요청
-  const requestTemporaryPassword = async ({ id, name, email }: {
-    id: string, name: string, email: string
+  const requestTemporaryPassword = async ({ id, email }: {
+    id: string, email: string
   }) => {
     setButtonLoadState(true);
     handleHelperClose();
@@ -68,7 +68,7 @@ export default function GetTemporaryPassword(): JSX.Element {
     try {
       const checkUserResponse = await axios.get('/users/check-exist-user', {
         params: {
-          id, name, email,
+          id, email,
         },
       });
       const userExist = checkUserResponse.data;
@@ -109,19 +109,23 @@ export default function GetTemporaryPassword(): JSX.Element {
   // 폼 제출 submit 핸들러
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
-    if (!userIdRef.current || !usernameRef.current || !usermailRef.current) {
+    if (!userIdRef.current || !usermailRef.current
+    // || !usernameRef.current
+    ) {
       return;
     }
     const id = userIdRef.current.value.trim();
-    const name = usernameRef.current.value.trim();
+    // const name = usernameRef.current.value.trim();
     const email = usermailRef.current.value.trim();
 
-    if (!id || !name || !email) {
+    if (!id || !email
+    // || !name 
+    ) {
       handleHelperOpen('아이디, 이름, 이메일을 입력해주세요');
       return;
     }
 
-    requestTemporaryPassword({ id, name, email });
+    requestTemporaryPassword({ id, email });
   };
 
   return (
@@ -130,7 +134,7 @@ export default function GetTemporaryPassword(): JSX.Element {
 
       <div className={classnames(classes.box, classes.content)}>
         <Typography variant="h6">회원 아이디와</Typography>
-        <Typography variant="h6">가입 시 사용한 이메일, 이름을 입력해주세요</Typography>
+        <Typography variant="h6">가입 시 사용한 이메일을 입력해주세요</Typography>
         <Typography className={classes.subcontent} variant="body2">
           가입시 입력한 이메일로 임시 비밀번호를 발송합니다.
         </Typography>
@@ -151,7 +155,7 @@ export default function GetTemporaryPassword(): JSX.Element {
             className={classes.inputField}
             inputProps={{ required: true }}
           />
-          <TextField
+          {/* <TextField
             name="name"
             color="primary"
             type="text"
@@ -160,7 +164,7 @@ export default function GetTemporaryPassword(): JSX.Element {
             autoComplete="off"
             className={classes.inputField}
             inputProps={{ required: true, minLength: 3 }}
-          />
+          /> */}
           <TextField
             name="email"
             color="primary"

--- a/server/src/resources/users/users.controller.ts
+++ b/server/src/resources/users/users.controller.ts
@@ -166,14 +166,13 @@ export class UsersController {
     return this.usersService.checkNickname(nickname);
   }
 
-  // id, 이메일, 이름으로 가입된 회원이 있는지 확인
+  // id, 이메일로 가입된 회원이 있는지 확인
   @Get('/check-exist-user')
   async checkExistUser(
     @Query('id') id: string,
-    @Query('name') name: string,
     @Query('email') email: string,
   ): Promise<boolean> {
-    return this.usersService.checkExistUser({ id, name, email });
+    return this.usersService.checkExistUser({ id, email });
   }
 
   // 비밀번호 변경

--- a/server/src/resources/users/users.controller.ts
+++ b/server/src/resources/users/users.controller.ts
@@ -131,9 +131,9 @@ export class UsersController {
     if (query.impUid) {
       const { userDI }: CertificationInfo = await this.authService
         .getCertificationInfo(query.impUid);
-      return this.usersService.findID(null, null, userDI);
+      return this.usersService.findID({ userDI });
     }
-    return this.usersService.findID(query.name, query.mail, null);
+    return this.usersService.findID({ mail: query.mail });
   }
 
   // 1. ID 값을 통해서 ID의 존재여부 확인.

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -350,16 +350,14 @@ export class UsersService {
     }
   }
 
-  // 이메일, 이름, id로 유저 존재하는지 파악
-  async checkExistUser({ email, name, id }: {
+  // 이메일, id로 유저 존재하는지 파악
+  async checkExistUser({ email, id }: {
     email: string,
-    name: string,
     id: string
   }): Promise<boolean> {
     const user = await this.usersRepository.findOne({
       where: {
         userId: id,
-        name,
         mail: email,
       },
     });

--- a/server/src/resources/users/users.service.ts
+++ b/server/src/resources/users/users.service.ts
@@ -295,7 +295,7 @@ export class UsersService {
 
   // User의 ID를 찾는 동기 함수. 결과값으로는 UserEntity의 인스턴스를 반환받되, 전달하는 것은 ID이다.
   // ID가 존재하지 않으면, ID에 대한 값을 null으로 전달한다.
-  async findID(name: string, mail?: string, userDI?: string): Promise<Pick<UserEntity, 'userId'>> {
+  async findID({ mail, userDI }: {mail?: string, userDI?: string}): Promise<Pick<UserEntity, 'userId'>> {
     // userDI의 존재여부에 따라서 조회방식을 분기한다.
     try {
       if (userDI) {
@@ -307,7 +307,9 @@ export class UsersService {
         return { userId: null };
       }
       const user = await this.usersRepository
-        .findOne({ where: { name, mail } });
+        .findOne({
+          where: { mail },
+        });
       if (user) {
         return { userId: user.userId };
       }


### PR DESCRIPTION
회원가입 화면에서 '이름' 입력칸 삭제함에 변경되어야 할 부분 수정

- 아이디 찾기에서 '이름' 입력칸 삭제
- 비밀번호 찾기에서 '이름' 입력칸 삭제
- 아이디 찾기(/users/id) 핸들러에서 name 파라미터 삭제
- 유저 존재여부 확인(/users/check-exist-user) 핸들러에서 name 파라미터 삭제