### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/production-api-server.yml
+++ b/.github/workflows/production-api-server.yml
@@ -40,7 +40,7 @@ jobs:
           yarn build
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           NODE_ENV: production
         with:

--- a/.github/workflows/production-collectors-twitchtv-chat.yml
+++ b/.github/workflows/production-collectors-twitchtv-chat.yml
@@ -29,7 +29,7 @@ jobs:
           yarn build
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_USERNAME }}/whiletrue-twitch-chat
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/production-collectors-twitchtv.yml
+++ b/.github/workflows/production-collectors-twitchtv.yml
@@ -23,7 +23,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_USERNAME }}/whiletrue-twitch-collector
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/test-api-server.yml
+++ b/.github/workflows/test-api-server.yml
@@ -40,7 +40,7 @@ jobs:
           yarn build
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           NODE_ENV: test
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore